### PR TITLE
Script less Linux-centric, more UNIX-agnostic

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # -----------------------------------------------------------------------------
 # Make sure everything really stops when CTRL+C is pressed


### PR DESCRIPTION
On FreeBSD and Solaris, Bash isn't by default located in /bin.

This shebang line will find it according the environment path.
