### PR TITLE
Force deleting INPROGRESS_FILE

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -282,7 +282,7 @@ while [ "1" ]; do
 	ln -s -- $(basename -- "$DEST") "latest"
 	cd -
 
-	rm -- "$INPROGRESS_FILE"
+	rm -f -- "$INPROGRESS_FILE"
 	# TODO: grep for "^rsync error:.*$" in log
 	fn_log_info "Backup completed without errors."
 	exit 0


### PR DESCRIPTION
avoids waiting for user input if rm is aliased to rm -i
