### PR TITLE
display usage info if required args not passed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 test.sh
+*~

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -25,7 +25,7 @@ trap 'fn_terminate_script' SIGINT
 # Small utility functions for reducing code duplication
 # -----------------------------------------------------------------------------
 fn_display_usage() {
-	fn_log_info "Usage : $(basename $0) <source> <destination> [exclude-pattern file]"
+	fn_log_info "Usage : $(basename $0) <source> [destination] [exclude-pattern file]"
 }
 
 fn_parse_date() {
@@ -57,13 +57,19 @@ fn_expire_backup() {
 # Source and destination information
 # -----------------------------------------------------------------------------
 #display usage information if required arguments are not passed
-if [[ "${#@}" -lt 2 ]]; then
+if [[ "${#@}" -lt 1 ]]; then
 	fn_display_usage
 	exit 1
 fi
 
 SRC_FOLDER="${1%/}"
-DEST_FOLDER="${2%/}"
+#if destination folder is not specified assume current folder
+if [ -z ${2} ]; then
+	DEST_FOLDER="."
+	echo ${2}
+else
+	DEST_FOLDER="${2%/}"
+fi
 EXCLUSION_FILE="$3"
 
 for ARG in "$SRC_FOLDER" "$DEST_FOLDER" "$EXCLUSION_FILE"; do

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -32,7 +32,7 @@ trap 'fn_terminate_script' SIGINT
 # Small utility functions for reducing code duplication
 # -----------------------------------------------------------------------------
 fn_display_usage() {
-	fn_log_info "Usage : $(basename $0) <source> [[[user@host:]destination] exclude-pattern-file]"
+	fn_log_info "Usage : $(basename $0) <source> <[user@host:]destination> [exclude-pattern-file]"
 }
 
 fn_parse_date() {
@@ -114,18 +114,12 @@ SSH_CMD=""
 SSH_FOLDER_PREFIX=""
 
 #display usage information if required arguments are not passed
-if [[ "${#@}" -lt 1 ]]; then
+if [[ "${#@}" -lt 2 ]]; then
 	fn_display_usage
 	exit 1
 fi
 SRC_FOLDER="${1%/}"
-
-#if destination folder is not specified assume current folder
-if [ -z ${2} ]; then
-	DEST_FOLDER="."
-else
-	DEST_FOLDER="${2%/}"
-fi
+DEST_FOLDER="${2%/}"
 EXCLUSION_FILE="$3"
 
 fn_parse_ssh

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -24,6 +24,9 @@ trap 'fn_terminate_script' SIGINT
 # -----------------------------------------------------------------------------
 # Small utility functions for reducing code duplication
 # -----------------------------------------------------------------------------
+fn_display_usage() {
+	fn_log_info "Usage : $(basename $0) <source> <destination> [exclude-pattern file]"
+}
 
 fn_parse_date() {
 	# Converts YYYY-MM-DD-HHMMSS to YYYY-MM-DD HH:MM:SS and then to Unix Epoch.
@@ -53,6 +56,11 @@ fn_expire_backup() {
 # -----------------------------------------------------------------------------
 # Source and destination information
 # -----------------------------------------------------------------------------
+#display usage information if required arguments are not passed
+if [[ "${#@}" -lt 2 ]]; then
+	fn_display_usage
+	exit 1
+fi
 
 SRC_FOLDER="${1%/}"
 DEST_FOLDER="${2%/}"


### PR DESCRIPTION
Added a function to display usage information, when the required arguments are not passed as input, instead of just assigning spaces to source and destination folder and displaying irrelevant error message.
