### PR TITLE
start the rsync process with ionice

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -55,7 +55,7 @@ fn_expire_backup() {
 # -----------------------------------------------------------------------------
 
 fn_compose_command() {
-    CMD="ionice -c 3"
+	CMD="ionice -c 3"
 	CMD="$CMD rsync"
 	CMD="$CMD --compress"
 	CMD="$CMD --numeric-ids"


### PR DESCRIPTION
Wouldn't it be a nice feature to let the rsync process run nice in terms of IO? It gains benefits for desktop users who like to continue to work on the machine while the backup is in progress.

Second update is the outsourcing of the composition of the rsync command into a separate function
