### PR TITLE
Adds support for exclude list instead of exclude file.

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -208,9 +208,9 @@ while : ; do
 		# FlyinButrs: If $EXCLUSION_FILE is a file that exists, pass it as a file. If not, use it as a string exclude.
 		# 
 		if [ -f "$EXCLUSION_FILE" ]; then
-			CMD="$CMD --exclude '$EXCLUSION_FILE'"
-		else 
 			CMD="$CMD --exclude-from '$EXCLUSION_FILE'"
+		else 
+			CMD="$CMD --exclude '$EXCLUSION_FILE'"
 		fi
 	fi
 	CMD="$CMD $LINK_DEST_OPTION"

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -210,7 +210,10 @@ while : ; do
 		if [ -f "$EXCLUSION_FILE" ]; then
 			CMD="$CMD --exclude-from '$EXCLUSION_FILE'"
 		else 
-			CMD="$CMD --exclude '$EXCLUSION_FILE'"
+                        for EXCPATT in $(echo $EXCLUSION_FILE | tr " " "\n")
+                        do
+                              CMD="$CMD --exclude '$EXCPATT'"
+                        done
 		fi
 	fi
 	CMD="$CMD $LINK_DEST_OPTION"

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -204,7 +204,14 @@ while : ; do
 	CMD="$CMD --log-file '$LOG_FILE'"
 	if [ -n "$EXCLUSION_FILE" ]; then
 		# We've already checked that $EXCLUSION_FILE doesn't contain a single quote
-		CMD="$CMD --exclude-from '$EXCLUSION_FILE'"
+		#
+		# FlyinButrs: If $EXCLUSION_FILE is a file that exists, pass it as a file. If not, use it as a string exclude.
+		# 
+		if [ -f "$EXCLUSION_FILE" ]; then
+			CMD="$CMD --exclude '$EXCLUSION_FILE'"
+		else 
+			CMD="$CMD --exclude-from '$EXCLUSION_FILE'"
+		fi
 	fi
 	CMD="$CMD $LINK_DEST_OPTION"
 	CMD="$CMD -- '$SRC_FOLDER/' '$DEST/'"


### PR DESCRIPTION
The exclusion_file argument is now checked to see if it's a file that exists, and if not, is assumed to be a space separated list of exclusion arguments, which are parsed and each added to the rsync command string.