### PR TITLE
prevent execution of concurrent backup tasks version #2

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -113,6 +113,10 @@ fi
 # -----------------------------------------------------------------------------
 
 if [ -f "$INPROGRESS_FILE" ]; then
+	if pgrep -F "$INPROGRESS_FILE" > /dev/null 2>&1 ; then
+		fn_log_error "Previous backup task is still active - aborting."
+		exit 1
+	fi
 	if [ -n "$PREVIOUS_DEST" ]; then
 		# - Last backup is moved to current backup folder so that it can be resumed.
 		# - 2nd to last backup becomes last backup.
@@ -123,6 +127,8 @@ if [ -f "$INPROGRESS_FILE" ]; then
 		else
 			PREVIOUS_DEST=""
 		fi
+		# update PID to current process to avoid multiple concurrent resumes
+		echo "$$" > "$INPROGRESS_FILE"
 	fi
 fi
 
@@ -213,7 +219,7 @@ while : ; do
 	fn_log_info "Running command:"
 	fn_log_info "$CMD"
 
-	touch -- "$INPROGRESS_FILE"
+	echo "$$" > "$INPROGRESS_FILE"
 	eval $CMD
 
 	# -----------------------------------------------------------------------------


### PR DESCRIPTION
This should now work at least on Linux and OSX, probably also with cygwin.
NEW: Once the backup task is resumed, PID inside  $INPROGRESS_FILE is updated to prevent multiple concurrent resumes.