### PR TITLE
PID reuse

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -113,7 +113,7 @@ fi
 # -----------------------------------------------------------------------------
 
 if [ -f "$INPROGRESS_FILE" ]; then
-	if pgrep -F "$INPROGRESS_FILE" > /dev/null 2>&1 ; then
+	if pgrep -F "$INPROGRESS_FILE" "$APPNAME"> /dev/null 2>&1 ; then
 		fn_log_error "Previous backup task is still active - aborting."
 		exit 1
 	fi


### PR DESCRIPTION
Checks for PID and $APPNAME in the results from pgrep in order to avoid
the problem where the PID from a previous run has been recycled by
another process.  This caused us to exit even though we are not
currently running.