### PR TITLE
Escaped double quotes on fn_run_cmd function. Closes #41.

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -42,7 +42,7 @@ fn_parse_date() {
 }
 
 fn_find_backups() {
-    fn_run_cmd "find "$DEST_FOLDER" -type d -name "????-??-??-??????" -prune | sort -r"
+    fn_run_cmd "find $DEST_FOLDER -type d -name \"????-??-??-??????\" -prune | sort -r"
 }
 
 fn_expire_backup() {
@@ -181,7 +181,7 @@ if [ -n "$(fn_find "$INPROGRESS_FILE")" ]; then
 		# TODO: so the pgrep solution below won't work. Need to use "procps -wwFAH", grep
 		# TODO: the script name, and extract the process ID from it.
 		fn_log_warn "Cygwin only: Previous backup task has either been interrupted or it might still be active, but there is currently no check for this. Assuming that the task was simply interrupted."
-	else 
+	else
 	    RUNNINGPID="$(fn_run_cmd "cat $INPROGRESS_FILE")"
 	    if [ "$RUNNINGPID"="$(pgrep "$APPNAME")" ]; then
 	        fn_log_error "Previous backup task is still active - aborting."


### PR DESCRIPTION
Also, apparently my editor cleaned up a trailing space lolz.
