### PR TITLE
Fixes issue with incorrectly detecting if backup is already running if interrupted

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -191,7 +191,7 @@ if [ -n "$(fn_find "$INPROGRESS_FILE")" ]; then
 		fn_log_warn "Cygwin only: Previous backup task has either been interrupted or it might still be active, but there is currently no check for this. Assuming that the task was simply interrupted."
 	else 
 	    RUNNINGPID="$(fn_run_cmd "cat $INPROGRESS_FILE")"
-	    if [ "$RUNNINGPID"="$(pgrep "$APPNAME")" ]; then
+	    if [ "$RUNNINGPID" = "$(pgrep "$APPNAME")" ]; then
 	        fn_log_error "Previous backup task is still active - aborting."
 	        exit 1
 	    fi


### PR DESCRIPTION
Lack of whitespace around the equals sign made `test` always return 0, so if a `backup.inprogress` file was present, subsequent backups always failed regardless of the actual running state of the script.