### PR TITLE
fixed check for previous backups in zsh

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -60,7 +60,7 @@ fn_parse_date() {
 }
 
 fn_find_backups() {
-	fn_run_cmd "find "$DEST_FOLDER" -maxdepth 1 -type d -name "????-??-??-??????" -prune | sort -r"
+	fn_run_cmd "find "$DEST_FOLDER" -maxdepth 1 -type d -name \"????-??-??-??????\" -prune | sort -r"
 }
 
 fn_expire_backup() {


### PR DESCRIPTION
Checking for previous backups was not working when the DEST_FOLDER is using a zsh shell.
I added to backslashes in `fn_find_backups`
I tested this fix on Windows and Linux