### PR TITLE
Also detect single dashes as error

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -182,7 +182,7 @@ while :; do
 			EXCLUSION_FILE="$3"
 			break
 			;;
-		-?*)
+		-*)
 			fn_log_error "Unknown option: \"$1\""
 			fn_log_info ""
 			fn_display_usage


### PR DESCRIPTION
This also recognizes single dashes as invalid input:

    rsync_tmbackup.sh - 1 2 3

Expected output: an error because it's unknown what the single `-` could mean

Actual output:

    rsync_tmbackup: Safety check failed - the destination does not appear to be a backup folder or drive (marker file not found).
    rsync_tmbackup: If it is indeed a backup folder, you may add the marker file by running the following command:
    rsync_tmbackup: 
    rsync_tmbackup: mkdir -p -- "1" ; touch "1/backup.marker"
    rsync_tmbackup: