### PR TITLE
Parse the --strategy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ On macOS, it has a few disadvantages compared to Time Machine - in particular it
 	 --log-dir            Set the log file directory. If this flag is set, generated files will
 	                      not be managed by the script - in particular they will not be
 	                      automatically deleted.
+     --strategy           Set the expiration strategy. Default: "1:1, 30:7, 365:30" means after one
+                          day, keep one backup per day. After 30 days, keep one backup every 7 days.
+                          After 365 days keep one backup every 30 days.
 
 ## Features
 


### PR DESCRIPTION
This pull request parses the --strategy option into a two dimensional array named `EXPIRATION_STRATEGY_MATRIX`.

The result of the parser is written in textform right before the expiration process.

At this point, it has no influence whatsoever on the actual deletion. It is only parsing the option and creating the array. The expiration strategy has not changed!