### PR TITLE
Fix to assure only one instance is running.

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -103,7 +103,7 @@ fn_parse_ssh() {
 }
 
 fn_run_cmd() {
-	if [ -n "$SSH_DEST_FOLDER_PREFIX" ] 
+	if [ -n "$SSH_DEST_FOLDER_PREFIX" ]
 	then
 		eval "$SSH_CMD '$1'"
 	else
@@ -305,9 +305,9 @@ if [ -n "$(fn_find "$INPROGRESS_FILE")" ]; then
 			fn_log_error "Previous backup task is still active - aborting (command: $RUNNINGCMD)."
 			exit 1
 		fi
-	else 
+	else
 		RUNNINGPID="$(fn_run_cmd "cat $INPROGRESS_FILE")"
-		if [ "$RUNNINGPID" = "$(pgrep "$APPNAME")" ]; then
+		if [ "$RUNNINGPID" = "$(pgrep -o -f "$APPNAME")" ]; then
 			fn_log_error "Previous backup task is still active - aborting."
 			exit 1
 		fi


### PR DESCRIPTION
Since this script runs under /usr/bin/env, running 'pgrep $0' will fail
due to it being a child of 'bash'. In order to fix this, pgrep must use
the `-o` flag (oldest pid, or in this case, the leader), and `-f` which
searches the full process name.