### PR TITLE
Improved fix to assure only one instance is running.

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -307,7 +307,8 @@ if [ -n "$(fn_find "$INPROGRESS_FILE")" ]; then
 		fi
 	else
 		RUNNINGPID="$(fn_run_cmd "cat $INPROGRESS_FILE")"
-		if [ "$RUNNINGPID" = "$(pgrep -o -f "$APPNAME")" ]; then
+		RUNNINGPIDBASENAME="$(basename $(ps -p $RUNNINGPID -o cmd= | cut -d " " -f 2) 2>/dev/null)"
+		if [ "${RUNNINGPIDBASENAME}" = "$(basename $0)" ]; then
 			fn_log_error "Previous backup task is still active - aborting."
 			exit 1
 		fi


### PR DESCRIPTION
The command 'pgrep -o -f "$APPNAME"' is not safe, as it might return,
e.g. a running editor session were something with $APPNAME is edited!

Also, some users might want to run two backups simultaneously:

   rsync-time-backup => DEST1 (oldest PID)
   rsync-time-backup => DEST2 (2nd oldest PID)

In that case, simply comparing the oldest PID of APPNAME with RUNNINGPID
will not prevent starting of several instances of the backup to DEST2.

Instead one should check, as done for cygwin (some lines above), whether
the process currently running under RUNNINGPID is identical with $APPNAME.