### PR TITLE
Add option to disable automatic purging of backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ On macOS, it has a few disadvantages compared to Time Machine - in particular it
 	 --strategy           Set the expiration strategy. Default: "1:1 30:7 365:30" means after one
 	                      day, keep one backup per day. After 30 days, keep one backup every 7 days.
 	                      After 365 days keep one backup every 30 days.
+	 --no-auto-expire     Set option to disable automatically purging old backups when out of space.
 
 ## Features
 
@@ -91,6 +92,10 @@ To display the rsync options that are used for backup, run `./rsync_tmbackup.sh 
 
 	rsync_tmbackup --rsync-set-flags "--numeric-ids --links --hard-links \
 	--one-file-system --archive --no-perms --no-groups --itemize-changes" /src /dest
+
+## No automatic backup expiration
+
+An option to diable the default behaviour to purge old backups when out of space. This option is set with the `--no-auto-expire` flag.
 	
 	
 ## How to restore

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -46,6 +46,8 @@ fn_display_usage() {
 	echo " --strategy           Set the expiration strategy. Default: \"1:1 30:7 365:30\" means after one"
 	echo "                      day, keep one backup per day. After 30 days, keep one backup every 7 days."
 	echo "                      After 365 days keep one backup every 30 days."
+	echo " --no-auto-expire     Disable automatically deleting backups when out of space. Instead an error"
+	echo "                      is logged, and the backup is aborted."
 	echo ""
 	echo "For more detailed help, please see the README file:"
 	echo ""
@@ -215,6 +217,7 @@ EXCLUSION_FILE=""
 LOG_DIR="$HOME/.$APPNAME"
 AUTO_DELETE_LOG="1"
 EXPIRATION_STRATEGY="1:1 30:7 365:30"
+AUTO_EXPIRE="1"
 
 RSYNC_FLAGS="-D --compress --numeric-ids --links --hard-links --one-file-system --itemize-changes --times --recursive --perms --owner --group --stats --human-readable"
 
@@ -245,6 +248,9 @@ while :; do
 			shift
 			LOG_DIR="$1"
 			AUTO_DELETE_LOG="0"
+			;;
+		--no-auto-expire)
+			AUTO_EXPIRE="0"
 			;;
 		--)
 			shift
@@ -459,6 +465,12 @@ while : ; do
 	NO_SPACE_LEFT="$(grep "No space left on device (28)\|Result too large (34)" "$LOG_FILE")"
 
 	if [ -n "$NO_SPACE_LEFT" ]; then
+
+		if [[ $AUTO_EXPIRE == "0" ]]; then
+			fn_log_error "No space left on device, and automatic purging of old backups is disabled."
+			exit 1
+		fi
+
 		fn_log_warn "No space left on device - removing oldest backup and resuming."
 
 		if [[ "$(fn_find_backups | wc -l)" -lt "2" ]]; then


### PR DESCRIPTION
Add option to disable automatic purging of backups when out of space `--no-auto-expire`. Default script behaviour is unchanged if option is not set.