### PR TITLE
fix checking of running pid

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -377,7 +377,7 @@ if [ -n "$(fn_find "$INPROGRESS_FILE")" ]; then
 		fi
 	
 		RUNNINGPID="$(fn_run_cmd "cat $INPROGRESS_FILE")"
-		if ps -${PSFLAGS}p "$RUNNINGPID" -o "command" | grep "$APPNAME" > /dev/null; then
+		if ps -${PSFLAGS}p "$RUNNINGPID" -o "command" | grep -q "$APPNAME"; then
                         fn_log_error "Previous backup task is still active - aborting."
                         exit 1
                 fi

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -370,18 +370,17 @@ if [ -n "$(fn_find "$INPROGRESS_FILE")" ]; then
 			fn_log_error "Previous backup task is still active - aborting (command: $RUNNINGCMD)."
 			exit 1
 		fi
-	elif [[ "$OSTYPE" == "netbsd"* ]]; then
+	else
+		PSFLAGS=''
+		if [[ "$OSTYPE" == "netbsd"* ]]; then
+			PSFLAGS=ax
+		fi
+	
 		RUNNINGPID="$(fn_run_cmd "cat $INPROGRESS_FILE")"
-		if ps -axp "$RUNNINGPID" -o "command" | grep "$APPNAME" > /dev/null; then
+		if ps -${PSFLAGS}p "$RUNNINGPID" -o "command" | grep "$APPNAME" > /dev/null; then
                         fn_log_error "Previous backup task is still active - aborting."
                         exit 1
                 fi
-	else
-		RUNNINGPID="$(fn_run_cmd "cat $INPROGRESS_FILE")"
-		if [ "$RUNNINGPID" = "$(pgrep -o -f "$APPNAME")" ]; then
-			fn_log_error "Previous backup task is still active - aborting."
-			exit 1
-		fi
 	fi
 
 	if [ -n "$PREVIOUS_DEST" ]; then


### PR DESCRIPTION
When pgrep lists multiple pids, the check for a pid fails.
Use the same logic as for NETBSD, with some flags of ps adapted because they mean something different.