### PR TITLE
Added ability to perform a dry run, utilizing rsync's --dry-run flag …

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ On macOS, it has a few disadvantages compared to Time Machine - in particular it
 	Options
 	 -p, --port           SSH port.
 	 -h, --help           Display this help message.
+	 -n, --dry-run        Performs a dry run, i.e. output without the backup (log files will be generated)
 	 --rsync-get-flags    Display the default rsync flags that are used for backup.
 	 --rsync-set-flags    Set the rsync flags that are going to be used for backup.
 	 --log-dir            Set the log file directory. If this flag is set, generated files will
@@ -44,6 +45,8 @@ On macOS, it has a few disadvantages compared to Time Machine - in particular it
 * Automatically purge old backups - within 24 hours, all backups are kept. Within one month, the most recent backup for each day is kept. For all previous backups, the most recent of each month is kept.
 
 * "latest" symlink that points to the latest successful backup.
+
+* Configuration testing of the command may be performed using the `--dry-run` parameter.
 
 ## Examples
 	

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-#set -x
 
 APPNAME=$(basename $0 | sed "s/\.sh$//")
 


### PR DESCRIPTION
In addition to not performing the backup, no folders are created, no backups are expired, and no files are symlinked. Rsync logs will be generated, but will follow the existing log deletion logic. 

This is very useful when testing if the flags and arguments are correct, or even when testing an exclusions file. 

Updated documentation on --dry-run parameter.