### PR TITLE
No compilant example for check mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ On macOS, it has a few disadvantages compared to Time Machine - in particular it
 * To mimic Time Machine's behaviour, a cron script can be setup to backup at regular interval. For example, the following cron job checks if the drive "/mnt/backup" is currently connected and, if it is, starts the backup. It does this check every 1 hour.
 
 		0 */1 * * * if [[ -d /mnt/backup ]]; then rsync_tmbackup.sh /home /mnt/backup; fi
+		
+		0 */1 * * * if grep -qs /mnt/backup /proc/mounts; then rsync_tmbackup.sh /home /mnt/backup; fi
 
 ## Backup expiration logic
 


### PR DESCRIPTION
`0 */1 * * * if [[ -d /mnt/backup ]]; then rsync_tmbackup.sh /home /mnt/backup; fi` this is not valid for all sistems. Is not POSIX compilant. IMHO best soltuion is `if grep -qs /mnt/backup /proc/mounts; then rsync_tmbackup.sh /home /mnt/backup; fi`

Best regards and thanks for your script.