### PR TITLE
bugfix - fn_expire_backups function

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -95,8 +95,9 @@ fn_expire_backups() {
 	local current_timestamp=$EPOCH
 	local last_kept_timestamp=9999999999
 
-	# Process each backup dir from most recent to oldest
-	for backup_dir in $(fn_find_backups | sort -r); do
+	# Process each backup dir from the oldest to the most recent
+	for backup_dir in $(fn_find_backups | sort); do
+
 		local backup_date=$(basename "$backup_dir")
 		local backup_timestamp=$(fn_parse_date "$backup_date")
 
@@ -106,36 +107,56 @@ fn_expire_backups() {
 			continue
 		fi
 
+		# If this is the first "for" iteration backup_dir points to the oldest backup
+		if [ "$last_kept_timestamp" == "9999999999" ]; then
+			# We dont't want to delete the oldest backup. It becomes first "last kept" backup
+			last_kept_timestamp=$backup_timestamp
+			# As we keep it we can skip processing it and go to the next oldest one
+			continue
+		fi
+
 		# Find which strategy token applies to this particular backup
 		for strategy_token in $(echo $EXPIRATION_STRATEGY | tr " " "\n" | sort -r -n); do
 			IFS=':' read -r -a t <<< "$strategy_token"
 
-			# After which date (relative to today) this token applies (X)
+			# After which date (relative to today) this token applies (X) - we use seconds to get exact cut off time
 			local cut_off_timestamp=$((current_timestamp - ${t[0]} * 86400))
 
-			# Every how many days should a backup be kept past the cut off date (Y)
-			local cut_off_interval=$((${t[1]} * 86400))
+			# Every how many days should a backup be kept past the cut off date (Y) - we use days (not seconds)
+			local cut_off_interval_days=$((${t[1]}))
 
 			# If we've found the strategy token that applies to this backup
 			if [ "$backup_timestamp" -le "$cut_off_timestamp" ]; then
 
 				# Special case: if Y is "0" we delete every time
-				if [ $cut_off_interval -eq "0" ]; then
+				if [ $cut_off_interval_days -eq "0" ]; then
 					fn_expire_backup "$backup_dir"
 					break
 				fi
 
+				# we calculate days number since last kept backup
+				local last_kept_timestamp_days=$((last_kept_timestamp / 86400))
+				local backup_timestamp_days=$((backup_timestamp / 86400))
+				local interval_since_last_kept_days=$((backup_timestamp_days - last_kept_timestamp_days))
+
 				# Check if the current backup is in the interval between
 				# the last backup that was kept and Y
-				local interval_since_last_kept=$((last_kept_timestamp - backup_timestamp))
-				if [ "$interval_since_last_kept" -lt "$cut_off_interval" ]; then
+				# to determine what to keep/delete we use days difference
+				if [ "$interval_since_last_kept_days" -lt "$cut_off_interval_days" ]; then
+
 					# Yes: Delete that one
 					fn_expire_backup "$backup_dir"
+					# backup deleted no point to check shorter timespan strategies - go to the next backup
+					break
+
 				else
-					# No: Keep it
+
+					# No: Keep it.
+					# af we keep it this is now the last kept backup
 					last_kept_timestamp=$backup_timestamp
+					# and go to the next backup
+					break
 				fi
-				break
 			fi
 		done
 	done


### PR DESCRIPTION
I have fixed  fn_expire_backups function in relation to bug reported here https://github.com/laurent22/rsync-time-backup/issues/121

Backups are now processed from the oldest one to the latest. 

The oldest backup is always kept during pruning. In my opinion this is the safest way to ensure that user has in the archive at least what was originally backuped there.

Decision if to keep or delete backup is now made using day values (instead of seconds). This fixes all issue with wrongly pruned backups making original strategy concept working as intended. 