### PR TITLE
bugfix -  built in lock - linux

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -397,7 +397,8 @@ if [ -n "$(fn_find "$INPROGRESS_FILE")" ]; then
                 fi
 	else
 		RUNNINGPID="$(fn_run_cmd "cat $INPROGRESS_FILE")"
-		if [ "$RUNNINGPID" = "$(pgrep -o -f "$APPNAME")" ]; then
+		if ps -p "$RUNNINGPID" -o command | grep "$APPNAME"
+		then
 			fn_log_error "Previous backup task is still active - aborting."
 			exit 1
 		fi


### PR DESCRIPTION
Fix for built in lock for linux.

https://github.com/laurent22/rsync-time-backup/issues/149

If backup is run to local disk rsync spawns two processes and $INPROGRESS_FILE contains PID of newer rsync instance than one returned by pgrep -o -f

Also some edge cases are not caught e.g. if there is another older rsync_tmbackup backup already running (to different destination) pgrep will pick up its PID instead of one of our backup we try to lock.

It is better explicitly check if process with PID from $INPROGRESS_FILE is running and it is another $APPNAME process.

so instead of
```
		RUNNINGPID="$(fn_run_cmd "cat $INPROGRESS_FILE")"
		if [ "$RUNNINGPID" = "$(pgrep -o -f "$APPNAME")" ]; then
			fn_log_error "Previous backup task is still active - aborting."
			exit 1
               fi
````
I use
```
                RUNNINGPID="$(fn_run_cmd "cat $INPROGRESS_FILE")"
                if ps -p "$RUNNINGPID" -o command | grep "$APPNAME"
                then
                        fn_log_error "Previous backup task is still active - aborting."
                        exit 1
                fi
```



