### PR TITLE
bugfix - built in lock - linux

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -398,7 +398,8 @@ if [ -n "$(fn_find "$INPROGRESS_FILE")" ]; then
                 fi
 	else
 		RUNNINGPID="$(fn_run_cmd "cat $INPROGRESS_FILE")"
-		if [ "$RUNNINGPID" = "$(pgrep -o -f "$APPNAME")" ]; then
+		if ps -p "$RUNNINGPID" -o command | grep "$APPNAME"
+		then
 			fn_log_error "Previous backup task is still active - aborting."
 			exit 1
 		fi


### PR DESCRIPTION
Existing lock does not work as pgrep can return multiple pid (if other backups are running) and in this case condition to abort won't be met. It will also happen when backup is run locally (e.g. to another filesystem) as in this case rsync spawns two processes.