### PR TITLE
bugfix fn expire backups

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -96,8 +96,9 @@ fn_expire_backups() {
 	local current_timestamp=$EPOCH
 	local last_kept_timestamp=9999999999
 
-	# Process each backup dir from most recent to oldest
-	for backup_dir in $(fn_find_backups | sort -r); do
+	# Process each backup dir from the oldest to the most recent
+	for backup_dir in $(fn_find_backups | sort); do
+
 		local backup_date=$(basename "$backup_dir")
 		local backup_timestamp=$(fn_parse_date "$backup_date")
 
@@ -107,41 +108,60 @@ fn_expire_backups() {
 			continue
 		fi
 
+		# If this is the first "for" iteration backup_dir points to the oldest backup
+		if [ "$last_kept_timestamp" == "9999999999" ]; then
+			# We dont't want to delete the oldest backup. It becomes first "last kept" backup
+			last_kept_timestamp=$backup_timestamp
+			# As we keep it we can skip processing it and go to the next oldest one
+			continue
+		fi
+
 		# Find which strategy token applies to this particular backup
 		for strategy_token in $(echo $EXPIRATION_STRATEGY | tr " " "\n" | sort -r -n); do
 			IFS=':' read -r -a t <<< "$strategy_token"
 
-			# After which date (relative to today) this token applies (X)
+			# After which date (relative to today) this token applies (X) - we use seconds to get exact cut off time
 			local cut_off_timestamp=$((current_timestamp - ${t[0]} * 86400))
 
-			# Every how many days should a backup be kept past the cut off date (Y)
-			local cut_off_interval=$((${t[1]} * 86400))
+			# Every how many days should a backup be kept past the cut off date (Y) - we use days (not seconds)
+			local cut_off_interval_days=$((${t[1]}))
 
 			# If we've found the strategy token that applies to this backup
 			if [ "$backup_timestamp" -le "$cut_off_timestamp" ]; then
 
 				# Special case: if Y is "0" we delete every time
-				if [ $cut_off_interval -eq "0" ]; then
+				if [ $cut_off_interval_days -eq "0" ]; then
 					fn_expire_backup "$backup_dir"
 					break
 				fi
 
+				# we calculate days number since last kept backup
+				local last_kept_timestamp_days=$((last_kept_timestamp / 86400))
+				local backup_timestamp_days=$((backup_timestamp / 86400))
+				local interval_since_last_kept_days=$((backup_timestamp_days - last_kept_timestamp_days))
+
 				# Check if the current backup is in the interval between
 				# the last backup that was kept and Y
-				local interval_since_last_kept=$((last_kept_timestamp - backup_timestamp))
-				if [ "$interval_since_last_kept" -lt "$cut_off_interval" ]; then
+				# to determine what to keep/delete we use days difference
+				if [ "$interval_since_last_kept_days" -lt "$cut_off_interval_days" ]; then
+
 					# Yes: Delete that one
 					fn_expire_backup "$backup_dir"
+					# backup deleted no point to check shorter timespan strategies - go to the next backup
+					break
+
 				else
-					# No: Keep it
+
+					# No: Keep it.
+					# this is now the last kept backup
 					last_kept_timestamp=$backup_timestamp
+					# and go to the next backup
+					break
 				fi
-				break
 			fi
 		done
 	done
 }
-
 fn_parse_ssh() {
 	# To keep compatibility with bash version < 3, we use grep
 	if echo "$DEST_FOLDER"|grep -Eq '^[A-Za-z0-9\._%\+\-]+@[A-Za-z0-9.\-]+\:.+$'

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -480,7 +480,7 @@ while : ; do
 	# Purge certain old backups before beginning new backup.
 	# -----------------------------------------------------------------------------
 
-        if [ -z "$PREVIOUS_DEST" ]; then
+        if [ -n "$PREVIOUS_DEST" ]; then
                 # regardless of expiry strategy keep backup used for --link-dest
                 fn_expire_backups "$PREVIOUS_DEST"
         else

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -97,9 +97,9 @@ fn_expire_backups() {
 	local last_kept_timestamp=9999999999
 
         # we will keep requested backup
-        BACKUP_TO_KEEP="$1"
+        backup_to_keep="$1"
         # we will also keep the oldest backup
-        OLDEST_BACKUP_TO_KEEP="$(fn_find_backups | sort | sed -n '1p')"
+        oldest_backup_to_keep="$(fn_find_backups | sort | sed -n '1p')"
 
 	# Process each backup dir from the oldest to the most recent
 	for backup_dir in $(fn_find_backups | sort); do
@@ -113,12 +113,12 @@ fn_expire_backups() {
 			continue
 		fi
 
-                if [ "$backup_dir" == "$BACKUP_TO_KEEP" ]; then
+                if [ "$backup_dir" == "$backup_to_keep" ]; then
                         # this is the latest backup requsted to be kept. We can finish pruning
                         break
                 fi
 
-                if [ "$backup_dir" == "$OLDEST_BACKUP_TO_KEEP" ]; then
+                if [ "$backup_dir" == "$oldest_backup_to_keep" ]; then
                        # We dont't want to delete the oldest backup. It becomes first "last kept" backup
                        last_kept_timestamp=$backup_timestamp
                        # As we keep it we can skip processing it and go to the next oldest one in the loop


### PR DESCRIPTION
in relation to #121  and #162 

In order to avoid situations described in #162  I have added extra parameter to fn_expire_backups.

Expiration algorithm is unchanged and only difference is that now function can be called with parameter indicating which backup to keep regardless of expiry strategy. This is the easiest approach as when function is used it is known which backup should be kept. E.g. if backup uses --link-dest its value should be used.

so function now is invokes as follows:

```
        if [ -n "$PREVIOUS_DEST" ]; then
                # regardless of expiry strategy keep backup used for --link-dest
                fn_expire_backups "$PREVIOUS_DEST"
        else
                # keep latest backup
                fn_expire_backups "$DEST"
        fi
```
and in fn_expire_backups I do extra check

```
        if [ "$backup_dir" == "$BACKUP_TO_KEEP" ]; then
                # this is the latest backup requsted to be kept. We can finish pruning
                break
        fi
```
simply we stop prunning when we get to the record we want to preserve (my function process backups from the oldest to the most recent).

In cases when fn_expire_backups would be called before backup starts or after it finishes the safest would be to pass latest backup as one to protect. This is advisable as there are expiry strategies like e.g. "1:1 5:0" when if new backup is run later than 5 days after the last one all backups could be pruned.

`        fn_expire_backups "$DEST"`
