### PR TITLE
Fix MacOS date parse when GNU date is present.

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -71,7 +71,7 @@ fn_parse_date() {
 			ss=`expr ${1:15:2}`
 			# Because under MacOS X Tiger 'date -j' doesn't work, we do this:
 			perl -e 'use Time::Local; print timelocal('$ss','$mi','$hh','$dd','$mm','$yy'),"\n";' ;;
-		darwin*) date -j -f "%Y-%m-%d-%H%M%S" "$1" "+%s" ;;
+		darwin*) /bin/date -j -f "%Y-%m-%d-%H%M%S" "$1" "+%s" ;;
 		FreeBSD*) date -j -f "%Y-%m-%d-%H%M%S" "$1" "+%s" ;;
 	esac
 }


### PR DESCRIPTION
If a MacOS user has installed GNU coreutils via Homebrew and updated
$PATH with the new 'gnubin' directory, then the flags supported by
'date' will differ and rsync_tmbackup.sh will throw the following:

[WARNING] Could not parse date

Why is the change necessary? (Bug fix, feature, improvements?)
- if GNU date has also been installed, and is overriding/preceding the
existing /bin/date binary in $PATH, GNU date will not know what the '-j'
flag does, and throws an error causing issues in fn_parse_date()

How does the change address the issue?
- by specifying the absolute path to the MacOS date binary, we can make
sure that the date binary we call supports the supplied flags