### PR TITLE
Add write permission to user before removal

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -89,6 +89,7 @@ fn_expire_backup() {
 	fi
 
 	fn_log_info "Expiring $1"
+	fn_run_cmd "chmod -R u+w $1"
 	fn_rm_dir "$1"
 }
 


### PR DESCRIPTION
If backup has expired and there are read only files the files won't be deleted and the backup will never expire.