### PR TITLE
fix source folder with spaces issue

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -369,7 +369,7 @@ if [ -n "$SSH_SRC_FOLDER" ]; then
 fi
 
 # Exit if source folder does not exist.
-if ! fn_test_file_exists_src ${SRC_FOLDER}; then
+if ! fn_test_file_exists_src "${SRC_FOLDER}"; then
 	fn_log_error "Source folder \"${SRC_FOLDER}\" does not exist - aborting."
 	exit 1
 fi


### PR DESCRIPTION
Fixes #172 . 
I seem to have forgotten the quotes around a variable, so it was not acting properly with source folder names containing spaces.
The quotes are added, and it works properly now.