### PR TITLE
Cron friendly

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -408,11 +408,11 @@ fi
 #
 # The check is performed by taking the second row
 # of the output of the first command.
-if [[ "$(fn_df_t_src "${SRC_FOLDER}" | awk '{print $2}' | grep -c -i -e "fat")" -gt 0 ]]; then
+if [[ "$(fn_df_t_src "${SRC_FOLDER}/" | awk '{print $2}' | grep -c -i -e "fat")" -gt 0 ]]; then
 	fn_log_info "Source file-system is a version of FAT."
 	fn_log_info "Using the --modify-window rsync parameter with value 2."
 	RSYNC_FLAGS="${RSYNC_FLAGS} --modify-window=2"
-elif [[ "$(fn_df_t "${DEST_FOLDER}" | awk '{print $2}' | grep -c -i -e "fat")" -gt 0 ]]; then
+elif [[ "$(fn_df_t "${DEST_FOLDER}/" | awk '{print $2}' | grep -c -i -e "fat")" -gt 0 ]]; then
 	fn_log_info "Destination file-system is a version of FAT."
 	fn_log_info "Using the --modify-window rsync parameter with value 2."
 	RSYNC_FLAGS="${RSYNC_FLAGS} --modify-window=2"

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -546,9 +546,9 @@ while : ; do
 	if [ -n "$SSH_CMD" ]; then
 		RSYNC_FLAGS="$RSYNC_FLAGS --compress"
 		if [ -n "$ID_RSA" ] ; then
-			CMD="$CMD  -e 'ssh -p $SSH_PORT -i $ID_RSA -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'"
+			CMD="$CMD  -e 'ssh -p $SSH_PORT -i $ID_RSA -o StrictHostKeyChecking=no'"
 		else
-			CMD="$CMD  -e 'ssh -p $SSH_PORT -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'"
+			CMD="$CMD  -e 'ssh -p $SSH_PORT -o StrictHostKeyChecking=no'"
 		fi
 	fi
 	CMD="$CMD $RSYNC_FLAGS"


### PR DESCRIPTION
Hello and thanks for this very useful tool!

Regarding #181, I made a couple changes that under circumstances always wrote to STDERR. This is a problem with cron where you usually redirect STDOUT to /dev/null but want to keep STDERR as is so that you get an email notification when a warning or error occurs. 

The first change was with the `df` check on SRC_FOLDER right after the trailling / is stripped. In the case of `SRC_FOLDER == /` , the / was stripped and df wrote to STDERR because FILE was the empty string.

The second change was the `-o UserKnownHostsFile=/dev/null` fixed ssh argument. This lead to ssh always writing to STDERR. This is part of #128. I would expect people to first setup the ssh access and then use rsync_tmbackup.sh. I cant' see a reason in bypassing the local configuration by default. There is always the `-e` option of rsync which can be used to set ssh options.

Best regards,

Panos