### PR TITLE
FreeBSD: "[WARNING] Could not parse date"

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -73,6 +73,7 @@ fn_parse_date() {
 			perl -e 'use Time::Local; print timelocal('$ss','$mi','$hh','$dd','$mm','$yy'),"\n";' ;;
 		darwin*) date -j -f "%Y-%m-%d-%H%M%S" "$1" "+%s" ;;
 		FreeBSD*) date -j -f "%Y-%m-%d-%H%M%S" "$1" "+%s" ;;
+		freebsd*) date -j -f "%Y-%m-%d-%H%M%S" "$1" "+%s" ;;
 	esac
 }
 


### PR DESCRIPTION
Fixes #137 

Tested on FreeBSD 12.0, $OSTYPE is reported as freebsd12.0, script expects FreeBSD12.0