### PR TITLE
Fallback to rsync returncode when logfile is not created

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -565,6 +565,7 @@ while : ; do
 
 	fn_run_cmd "echo $MYPID > $INPROGRESS_FILE"
 	eval $CMD
+	CMD_RETURNCODE=$?
 
 	# -----------------------------------------------------------------------------
 	# Check if we ran out of space
@@ -601,6 +602,8 @@ while : ; do
 		fn_log_error "Rsync reported an error. Run this command for more details: grep -E 'rsync:|rsync error:' '$LOG_FILE'"
 	elif [ -n "$(grep "rsync:" "$LOG_FILE")" ]; then
 		fn_log_warn "Rsync reported a warning. Run this command for more details: grep -E 'rsync:|rsync error:' '$LOG_FILE'"
+	elif [ $CMD_RETURNCODE -ne 0 ]; then
+		fn_log_error "Rsync returned non-zero return code, backup failed."
 	else
 		fn_log_info "Backup completed without errors."
 		if [[ $AUTO_DELETE_LOG == "1" ]]; then


### PR DESCRIPTION
All rsync error detection is based on the contents of the logfile. If the errors are not in the file, or if the logfile is not present, the backup script assumes everything went fine (!!!).

This PR uses the returncode as additional condition to marking the backup as successful.

```Apr 29 10:22:01 backup rsync_tmbackup[28480]: >f+++++++++ somedir/somefile
Apr 29 10:40:13 backup rsync_tmbackup[28480]: [generator] io timeout after 30 seconds -- exiting
Apr 29 10:40:13 backup rsync_tmbackup[28480]: rsync error: timeout in data send/receive (code 30) at io.c(204) [generator=3.1.3]
Apr 29 11:57:58 backup rsync_tmbackup[28480]: cd+++++++++ somedir
Apr 29 11:57:58 backup rsync_tmbackup[28480]: rsync: [sender] write error: Broken pipe (32)
Apr 29 11:57:58 backup rsync_tmbackup[28480]: rsync error: timeout in data send/receive (code 30) at io.c(829) [sender=3.1.3]
Apr 29 11:57:58 backup rsync_tmbackup[28480]: rsync_tmbackup: Backup completed without errors.
Apr 29 11:57:58 backup systemd[1]: backup-diskarray.service: Succeeded.
```