### PR TITLE
Prevent empty folder being used as latest backup.

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -441,14 +441,19 @@ while : ; do
 		EXIT_CODE="0"
 	fi
 
-	# -----------------------------------------------------------------------------
-	# Add symlink to last backup
-	# -----------------------------------------------------------------------------
+    	# -----------------------------------------------------------------------------
+    	# Add symlink to last backup if folder is not empty
+    	# -----------------------------------------------------------------------------
+    	if [ "$(ls -A "$DEST_FOLDER/$(basename -- "$DEST")")" ]; then
+        	fn_rm_file "$DEST_FOLDER/latest"
+        	fn_ln "$(basename -- "$DEST")" "$DEST_FOLDER/latest"
+    	else
+        	fn_rm_dir "$DEST_FOLDER/$(basename -- "$DEST")"
+    	fi
+    	fn_rm_file "$INPROGRESS_FILE"
 
-	fn_rm_file "$DEST_FOLDER/latest"
-	fn_ln "$(basename -- "$DEST")" "$DEST_FOLDER/latest"
+    exit $EXIT_CODE
 
-	fn_rm_file "$INPROGRESS_FILE"
 
 	exit $EXIT_CODE
 done

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -131,6 +131,10 @@ fn_ln() {
 	fn_run_cmd "ln -s -- '$1' '$2'"
 }
 
+fn_ls() {
+        fn_run_cmd "ls -- '$1'"
+} 
+
 # -----------------------------------------------------------------------------
 # Source and destination information
 # -----------------------------------------------------------------------------
@@ -444,7 +448,7 @@ while : ; do
     	# -----------------------------------------------------------------------------
     	# Add symlink to last backup if folder is not empty
     	# -----------------------------------------------------------------------------
-    	if [ "$(ls -A "$DEST_FOLDER/$(basename -- "$DEST")")" ]; then
+    	if [ "$(fn_ls "$DEST_FOLDER/$(basename -- "$DEST")")" ]; then
         	fn_rm_file "$DEST_FOLDER/latest"
         	fn_ln "$(basename -- "$DEST")" "$DEST_FOLDER/latest"
     	else

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -452,8 +452,5 @@ while : ; do
     	fi
     	fn_rm_file "$INPROGRESS_FILE"
 
-    exit $EXIT_CODE
-
-
 	exit $EXIT_CODE
 done


### PR DESCRIPTION
After completion of backup the folder is checked to see if it actually contains any files/directories.  If not, the folder is deleted and isn't used as the latest folder.
Fix for issue #86 