### PR TITLE
Add flag to enable secure SSH features

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ On macOS, it has a few disadvantages compared to Time Machine - in particular it
 	                        After 365 days keep one backup every 30 days.
 	 --no-auto-expire       Disable automatically deleting backups when out of space. Instead an error
 	                        is logged, and the backup is aborted.
+	 --secure-ssh           Enables secure SSH features.
 
 ## Features
 


### PR DESCRIPTION
Long time user

I recently _automated_ some of my rsync-time-backup backups with cron and now I get hourly emails warning me that the host key has been added to the list of known hosts

This is due to the `-o UserKnownHostsFile=/dev/null` SSH flag being used

I've added a flag `--secure-ssh` which is _disabled_ by default (so the current default behavior is maintained) but when enabled removes the SSH flag (thus _enabling_ the SSH security features)

I no longer get emails from Cron 👍

This closes #181 and #104 

Thanks!