### PR TITLE
fix: Quote `$0` and printed variable

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-APPNAME=$(basename $0 | sed "s/\.sh$//")
+APPNAME=$(basename "$0" | sed "s/\.sh$//")
 
 # -----------------------------------------------------------------------------
 # Log functions
@@ -32,7 +32,7 @@ trap 'fn_terminate_script' SIGINT
 # Small utility functions for reducing code duplication
 # -----------------------------------------------------------------------------
 fn_display_usage() {
-	echo "Usage: $(basename $0) [OPTION]... <[USER@HOST:]SOURCE> <[USER@HOST:]DESTINATION> [exclude-pattern-file]"
+	echo "Usage: $(basename "$0") [OPTION]... <[USER@HOST:]SOURCE> <[USER@HOST:]DESTINATION> [exclude-pattern-file]"
 	echo ""
 	echo "Options"
 	echo " -p, --port             SSH port."
@@ -298,7 +298,7 @@ while :; do
 			;;
 		--rsync-get-flags)
 			shift
-			echo $RSYNC_FLAGS
+			echo "$RSYNC_FLAGS"
 			exit
 			;;
 		--rsync-set-flags)


### PR DESCRIPTION
This addresses some low-hanging fruit mentioned in #89.

The `basename $0` is always a fix. If the path to the script contained spaces, then anything after the space will be considered a prefix (removing parts of the path), which would later make the `ps -axp "$RUNNINGPID" -o "command" | grep "$APPNAME" > /dev/null` result in false positives.

In the case of `echo $RSYNC_FLAGS`, it is the last thing run, and it does not change what is printed, which is a convenience to the user.