### PR TITLE
Update symlink and remove .inprogress only after success

### DIFF
--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -97,10 +97,10 @@ fn_expire_backups() {
 	local current_timestamp=$EPOCH
 	local last_kept_timestamp=9999999999
 
-		# we will keep requested backup
-		backup_to_keep="$1"
-		# we will also keep the oldest backup
-		oldest_backup_to_keep="$(fn_find_backups | sort | sed -n '1p')"
+	# we will keep requested backup
+	backup_to_keep="$1"
+	# we will also keep the oldest backup
+	oldest_backup_to_keep="$(fn_find_backups | sort | sed -n '1p')"
 
 	# Process each backup dir from the oldest to the most recent
 	for backup_dir in $(fn_find_backups | sort); do
@@ -467,9 +467,9 @@ if [ -n "$(fn_find "$INPROGRESS_FILE")" ]; then
 	elif [[ "$OSTYPE" == "netbsd"* ]]; then
 		RUNNINGPID="$(fn_run_cmd "cat $INPROGRESS_FILE")"
 		if ps -axp "$RUNNINGPID" -o "command" | grep "$APPNAME" > /dev/null; then
-						fn_log_error "Previous backup task is still active - aborting."
-						exit 1
-				fi
+			fn_log_error "Previous backup task is still active - aborting."
+			exit 1
+		fi
 	else
 		RUNNINGPID="$(fn_run_cmd "cat $INPROGRESS_FILE")"
 		if ps -p "$RUNNINGPID" -o command | grep "$APPNAME"
@@ -525,13 +525,13 @@ while : ; do
 	# Purge certain old backups before beginning new backup.
 	# -----------------------------------------------------------------------------
 
-		if [ -n "$PREVIOUS_DEST" ]; then
-			# regardless of expiry strategy keep backup used for --link-dest
-			fn_expire_backups "$PREVIOUS_DEST"
-		else
-			# keep latest backup
-			fn_expire_backups "$DEST"
-		fi
+	if [ -n "$PREVIOUS_DEST" ]; then
+		# regardless of expiry strategy keep backup used for --link-dest
+		fn_expire_backups "$PREVIOUS_DEST"
+	else
+		# keep latest backup
+		fn_expire_backups "$DEST"
+	fi
 
 	# -----------------------------------------------------------------------------
 	# Start backup

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -614,11 +614,13 @@ while : ; do
 	# Add symlink to last backup
 	# -----------------------------------------------------------------------------
 	if [ "$EXIT_CODE" = 0 ]; then
+		# Create the latest symlink only when rsync succeeded
 		fn_rm_file "$DEST_FOLDER/latest"
 		fn_ln "$(basename -- "$DEST")" "$DEST_FOLDER/latest"
-	fi
 
-	fn_rm_file "$INPROGRESS_FILE"
+		# Remove .inprogress file only when rsync succeeded
+		fn_rm_file "$INPROGRESS_FILE"
+	fi
 
 	exit $EXIT_CODE
 done

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -613,9 +613,10 @@ while : ; do
 	# -----------------------------------------------------------------------------
 	# Add symlink to last backup
 	# -----------------------------------------------------------------------------
-
-	fn_rm_file "$DEST_FOLDER/latest"
-	fn_ln "$(basename -- "$DEST")" "$DEST_FOLDER/latest"
+	if [ "$EXIT_CODE" = 0 ]; then
+		fn_rm_file "$DEST_FOLDER/latest"
+		fn_ln "$(basename -- "$DEST")" "$DEST_FOLDER/latest"
+	fi
 
 	fn_rm_file "$INPROGRESS_FILE"
 


### PR DESCRIPTION
Update symlink only after success. Otherwise the symlink 'latest' gives wrong info to the next backup on what have been backed up and what haven't.