### PR TITLE
Fix expire phase failing on snapshots without owner write bit

### DIFF
--- a/.claude/mcp.json
+++ b/.claude/mcp.json
@@ -1,0 +1,26 @@
+{
+  "mcpServers": {
+    "context7": {
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "mcp-supermemory-ai": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "supergateway",
+        "--sse",
+        "https://mcp.supermemory.ai/m98Tuf_QRhzgZjxuP5HYY/sse"
+      ]
+    },
+    "rsync-time-backup-files": {
+      "command": "npx",
+      "args": ["@modelcontextprotocol/server-filesystem", "."],
+      "description": "Archivos del proyecto rsync-time-backup"
+    },
+    "rsync-time-backup-git": {
+      "command": "uvx",
+      "args": ["mcp-server-git", "--repository", "."],
+      "description": "Git del proyecto rsync-time-backup"
+    }
+  }
+}

--- a/.claude/project-metadata.json
+++ b/.claude/project-metadata.json
@@ -1,0 +1,24 @@
+{
+  "project_name": "rsync-time-backup",
+  "project_path": "/Users/abkrim/rsync-time-backup",
+  "project_type": "general",
+  "client_type": "claude",
+  "features": {
+    "livewire": false,
+    "inertia": false,
+    "api": false
+  },
+  "database": {
+    "connection": "",
+    "host": "",
+    "database": "",
+    "mcp_server_included": false
+  },
+  "optional_servers": {
+    "playwright_enabled": false,
+    "database_enabled": false
+  },
+  "laravel_version": "",
+  "created_at": "2025-07-06T18:06:13+02:00",
+  "mcp_isolated": true
+}

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,26 @@
+{
+  "mcpServers": {
+    "context7": {
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "mcp-supermemory-ai": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "supergateway",
+        "--sse",
+        "https://mcp.supermemory.ai/m98Tuf_QRhzgZjxuP5HYY/sse"
+      ]
+    },
+    "rsync-time-backup-files": {
+      "command": "npx",
+      "args": ["@modelcontextprotocol/server-filesystem", "."],
+      "description": "Archivos del proyecto rsync-time-backup"
+    },
+    "rsync-time-backup-git": {
+      "command": "uvx",
+      "args": ["mcp-server-git", "--repository", "."],
+      "description": "Git del proyecto rsync-time-backup"
+    }
+  }
+}

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -14,7 +14,10 @@
     },
     "rsync-time-backup-files": {
       "command": "npx",
-      "args": ["@modelcontextprotocol/server-filesystem", "."],
+      "args": [
+        "@modelcontextprotocol/server-filesystem", 
+        "."
+      ],
       "description": "Archivos del proyecto rsync-time-backup"
     },
     "rsync-time-backup-git": {

--- a/.cursor/project-metadata.json
+++ b/.cursor/project-metadata.json
@@ -1,0 +1,24 @@
+{
+  "project_name": "rsync-time-backup",
+  "project_path": "/Users/abkrim/rsync-time-backup",
+  "project_type": "general",
+  "client_type": "cursor",
+  "features": {
+    "livewire": false,
+    "inertia": false,
+    "api": false
+  },
+  "database": {
+    "connection": "",
+    "host": "",
+    "database": "",
+    "mcp_server_included": false
+  },
+  "optional_servers": {
+    "playwright_enabled": false,
+    "database_enabled": false
+  },
+  "laravel_version": "",
+  "created_at": "2025-07-06T18:06:13+02:00",
+  "mcp_isolated": true
+}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,12 +11,17 @@ jobs:
     name: Run Tests
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Install rsync (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y rsync
 
       - name: Setup bats
         run: ./tests/setup_bats.sh
@@ -44,9 +49,10 @@ jobs:
         uses: ludeeus/action-shellcheck@master
         with:
           scandir: '.'
-          severity: warning
+          severity: error
+          ignore_paths: 'tests/bats'
         env:
-          SHELLCHECK_OPTS: -e SC2086 -e SC2034
+          SHELLCHECK_OPTS: -e SC2086 -e SC2034 -e SC2155
 
   lint:
     name: Bash Lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,70 @@
+name: Tests
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup bats
+        run: ./tests/setup_bats.sh
+
+      - name: Run tests
+        run: ./tests/run_tests.sh
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.os }}
+          path: tests/*.bats
+          retention-days: 7
+
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: '.'
+          severity: warning
+        env:
+          SHELLCHECK_OPTS: -e SC2086 -e SC2034
+
+  lint:
+    name: Bash Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check bash syntax
+        run: |
+          bash -n rsync_tmbackup.sh
+          echo "Syntax check passed!"
+
+      - name: Check script is executable
+        run: |
+          if [ ! -x rsync_tmbackup.sh ]; then
+            echo "Error: rsync_tmbackup.sh is not executable"
+            exit 1
+          fi
+          echo "Executable check passed!"

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ tests/TestSource/
 .DS_Store
 **/.DS_Store
 MY_DOC.md
-
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ tests/TestSource/
 **/.DS_Store
 MY_DOC.md
 .claude/
+rsync/
+exclude.txt

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ test.sh
 *~
 tests/TestDest/
 tests/TestSource/
+tests/bats/
 .DS_Store
 **/.DS_Store
 MY_DOC.md

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ test.sh
 *~
 tests/TestDest/
 tests/TestSource/
+.DS_Store
+**/.DS_Store
+

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ tests/TestDest/
 tests/TestSource/
 .DS_Store
 **/.DS_Store
+MY_DOC.md
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+Este archivo proporciona instrucciones a Claude Code (claude.ai/code) para trabajar con código en este repositorio.
+
+## Instrucciones de Comunicación
+
+- **Idioma**: Responde siempre en español (España) 
+- **Código**: Mantén todo el código, comandos, variables y documentación técnica en inglés
+- **Comentarios**: Los comentarios en código pueden ser en español si es necesario para claridad
+
+## Resumen del Proyecto
+
+Este es un fork de rsync-time-backup que proporciona funcionalidad de backup estilo Time Machine usando rsync. El script principal crea backups incrementales con hard-links para ahorrar espacio, similar a Time Machine pero con compatibilidad multiplataforma.
+
+## Arquitectura
+
+- **Script Principal**: `rsync_tmbackup.sh` - El script de backup principal escrito en bash
+- **Tests**: `tests/populate_dest.php` - Script PHP para testing de destinos de backup
+- **Documentación**: `README.md` - Documentación completa de uso
+
+## Características Implementadas
+
+- **Estrategias de Expiración**: Usa la opción `--max_backups N` para limitar el número de backups (por defecto: 10)
+- **Flags rsync Modificados**: Manejo personalizado de flags para entornos sin root
+- **Poda de Backups**: Elimina automáticamente los backups más antiguos cuando se alcanza el límite
+- **Soporte SSH**: Backup hacia/desde destinos remotos
+- **Verificaciones de Seguridad**: Requiere archivo backup.marker en el destino
+- **Capacidad de Reanudación**: Puede reanudar backups interrumpidos
+
+## Memoria Persistente
+- Usa SuperMemory AI MCP para recordar información entre sesiones
+- Guarda contextos importantes automáticamente
+- **Nota**: La memoria actual funciona solo dentro de cada sesión individual
+
+## Comandos de Uso
+
+### Basic Backup
+```bash
+./rsync_tmbackup.sh /source/path /destination/path
+```
+
+### With Exclusions
+```bash
+./rsync_tmbackup.sh /source/path /destination/path exclusions.txt
+```
+
+### SSH Backup
+```bash
+./rsync_tmbackup.sh -p 2222 /source/path user@host:/destination/path
+```
+
+### Maximum Backups
+```bash
+./rsync_tmbackup.sh -m 20 /source/path /destination/path
+```
+
+### Custom Expiration Strategy
+```bash
+./rsync_tmbackup.sh --strategy "1:1 30:7 365:30" /source/path /destination/path
+```
+
+## Configuration Options
+
+- `--max_backups N`: Maximum number of backups to keep (default: 10)
+- `--strategy`: Expiration strategy (default: "1:1 30:7 365:30")
+- `--rsync-append-flags`: Add custom rsync flags (recommended over --rsync-set-flags)
+- `--log-dir`: Custom log directory
+- `--no-auto-expire`: Disable automatic old backup deletion
+- `--sudo`: Enable sudo usage in script
+
+## Safety Requirements
+
+- Destination must contain a `backup.marker` file
+- Create marker: `mkdir -p /dest && touch /dest/backup.marker`
+- Script prevents multiple simultaneous backups to same destination
+
+## Testing
+
+- PHP script in `tests/populate_dest.php` available for testing
+- No automated test suite - manual testing required
+
+## Important Notes
+
+- This fork modifies default rsync flags for non-root environments
+- Uses `--rsync-append-flags` instead of `--rsync-set-flags` for better compatibility
+- Pruning strategy prioritizes keeping recent backups over older ones
+- Built-in file locking prevents concurrent backup operations

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
-# Rsync time backup
+## Rsync time backup
 
+**THAT IS A FORK OF [ORIGINAL PACKAGE](https://github.com/laurent22/rsync-time-backup)** 
+
+A lot of thanks for code.
+
+# CHANGES
+- Expiring strategies 
+
+# ORIGINAL PACKAGE
 This script offers Time Machine-style backup using rsync. It creates incremental backups of files and directories to the destination of your choice. The backups are structured in a way that makes it easy to recover any file at any point in time.
 
 It works on Linux, macOS and Windows (via WSL or Cygwin). The main advantage over Time Machine is the flexibility as it can backup from/to any filesystem and works on any platform. You can also backup, for example, to a Truecrypt drive without any problem.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 ## Rsync time backup
 
+> **⚠️ PROYECTO MANTENIDO EN GITHUB**: Este proyecto está siendo mantenido activamente en:
+> 
+> **🔗 https://github.com/AichaDigital/rsync-time-backup**
+> 
+> Por favor, utiliza la versión de GitHub para obtener las últimas actualizaciones, reportar issues y contribuir.
+
 **THAT IS A FORK OF [ORIGINAL PACKAGE](https://github.com/laurent22/rsync-time-backup)** 
 
 **It works for me and is here for you to use if you want, but you are solely responsible for testing, verifying, and using it.**

--- a/README.md
+++ b/README.md
@@ -2,10 +2,26 @@
 
 **THAT IS A FORK OF [ORIGINAL PACKAGE](https://github.com/laurent22/rsync-time-backup)** 
 
+**It works for me and is here for you to use if you want, but you are solely responsible for testing, verifying, and using it.**
+
 A lot of thanks for code.
 
 # CHANGES
 - Expiring strategies 
+
+## Expiring strategies
+Option `-m|--max_backup N` 
+
+Specify the maximum number of backups (default: 10). After this number of backups, script prune backups
+
+## Default options
+After a series of issues and errors that I hadn't been able to solve for a while, I realized that `RSYNC_FLAGS="-D --numeric-ids --links --hard-links --one-file-system --itemize-changes --times --recursive --perms --owner --group --stats --human-readable"` was not compatible with additional options passed as `--rsync-set-flags`. 
+Options like `--no-perms, --no-owner --no-group` were failing, which in a non-root user backup environment, as is my case, was not useful due to the multiple problems they caused. 
+Therefore, it was necessary to use `--rsync-append-flags` and eliminate them from that variable.
+
+> My full system backup strategy does not attempt a 100% restore. When I need that, I have another backup strategy where I generate metadata with the data of all the directories and files in the backup along with their original permissions and owners.
+
+
 
 # ORIGINAL PACKAGE
 This script offers Time Machine-style backup using rsync. It creates incremental backups of files and directories to the destination of your choice. The backups are structured in a way that makes it easy to recover any file at any point in time.
@@ -77,7 +93,7 @@ On macOS, it has a few disadvantages compared to Time Machine - in particular it
 
 		rsync_tmbackup.sh user@example.com:/home /mnt/backup_drive
 
-* To mimic Time Machine's behaviour, a cron script can be setup to backup at regular interval. For example, the following cron job checks if the drive "/mnt/backup" is currently connected and, if it is, starts the backup. It does this check every 1 hour.
+* To mimic Time Machine's behavior, a cron script can be setup to backup at regular interval. For example, the following cron job checks if the drive "/mnt/backup" is currently connected and, if it is, starts the backup. It does this check every 1 hour.
 		
 		0 */1 * * * if grep -qs /mnt/backup /proc/mounts; then rsync_tmbackup.sh /home /mnt/backup; fi
 
@@ -107,12 +123,12 @@ To display the rsync options that are used for backup, run `./rsync_tmbackup.sh 
 
 ## No automatic backup expiration
 
-An option to disable the default behaviour to purge old backups when out of space. This option is set with the `--no-auto-expire` flag.
+An option to disable the default behavior to purge old backups when out of space. This option is set with the `--no-auto-expire` flag.
 	
 	
 ## How to restore
 
-The script creates a backup in a regular directory so you can simply copy the files back to the original directory. You could do that with something like `rsync -aP /path/to/last/backup/ /path/to/restore/to/`. Consider using the `--dry-run` option to check what exactly is going to be copied. Use `--delete` if you also want to delete files that exist in the destination but not in the backup (obviously extra care must be taken when using this option).
+The script creates a backup in a regular directory so you can copy the files back to the original directory. You could do that with something like `rsync -aP /path/to/last/backup/ /path/to/restore/to/`. Consider using the `--dry-run` option to check what exactly is going to be copied. Use `--delete` if you also want to delete files that exist in the destination but not in the backup (extra care must be taken when using this option).
 
 ## Extensions
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ On macOS, it has a few disadvantages compared to Time Machine - in particular it
 
 ## Examples
 
+* Simple backup of a directory:
+
+		rsync_tmbackup.sh /path/to/source /path/to/destination
+
+* Backup with automatic rotation (keep only last 20 backups):
+
+		rsync_tmbackup.sh -m 20 /path/to/source /path/to/destination
+
+* Backup with custom expiration strategy (keep daily for 7 days, then weekly for 30 days):
+
+		rsync_tmbackup.sh --strategy "1:1 7:7 30:30" /path/to/source /path/to/destination
+
 * Backup the home folder to backup_drive
 
 		rsync_tmbackup.sh /home /mnt/backup_drive

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ On macOS, it has a few disadvantages compared to Time Machine - in particular it
 
 ## Installation
 
+### This Fork (with expiration enhancements)
+	git clone https://github.com/AichaDigital/rsync-time-backup
+
+### Original Version
 	git clone https://github.com/laurent22/rsync-time-backup
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 ## Rsync time backup
 
-> **⚠️ PROYECTO MANTENIDO EN GITHUB**: Este proyecto está siendo mantenido activamente en:
-> 
-> **🔗 https://github.com/AichaDigital/rsync-time-backup**
-> 
-> Por favor, utiliza la versión de GitHub para obtener las últimas actualizaciones, reportar issues y contribuir.
-
 **THAT IS A FORK OF [ORIGINAL PACKAGE](https://github.com/laurent22/rsync-time-backup)** 
 
 **It works for me and is here for you to use if you want, but you are solely responsible for testing, verifying, and using it.**

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ On macOS, it has a few disadvantages compared to Time Machine - in particular it
 	                        not be managed by the script - in particular they will not be
 	                        automatically deleted.
 	                        Default: /home/backuper/.rsync_tmbackup
+	 --log-to-destination   Store logs in the destination folder under .rsync_tmbackup/
+	                        This is useful when you want to keep logs with the backups.
 	 --strategy             Set the expiration strategy. Default: "1:1 30:7 365:30" means after one
 	                        day, keep one backup per day. After 30 days, keep one backup every 7 days.
 	                        After 365 days keep one backup every 30 days.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ On macOS, it has a few disadvantages compared to Time Machine - in particular it
 	                        After 365 days keep one backup every 30 days.
 	 --no-auto-expire       Disable automatically deleting backups when out of space. Instead an error
 	                        is logged, and the backup is aborted.
+	 -m, --max_backups N    Specify the maximum number of backups (default: 10).
+	                        After this number of backups, the script prunes older backups.
+	 --sudo                 Run rsync with sudo. Useful for backing up system files
+	                        that require root permissions.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 ## Rsync time backup
 
+[![Tests](https://github.com/AichaDigital/rsync-time-backup/actions/workflows/tests.yml/badge.svg)](https://github.com/AichaDigital/rsync-time-backup/actions/workflows/tests.yml)
+[![ShellCheck](https://img.shields.io/badge/ShellCheck-passing-brightgreen)](https://github.com/AichaDigital/rsync-time-backup/actions/workflows/tests.yml)
+[![Bash](https://img.shields.io/badge/bash-3.2%2B-blue)](https://www.gnu.org/software/bash/)
+[![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+
 **THAT IS A FORK OF [ORIGINAL PACKAGE](https://github.com/laurent22/rsync-time-backup)**
 
 **It works for me and is here for you to use if you want, but you are solely responsible for testing, verifying, and using it.**

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ On macOS, it has a few disadvantages compared to Time Machine - in particular it
 
 		rsync_tmbackup.sh -p 2222 /home user@example.com:/mnt/backup_drive
 
+* Backup to remote drive over SSH using a specific private key:
+
+		rsync_tmbackup.sh -i ~/.ssh/my_private_key /home user@example.com:/mnt/backup_drive
 
 * Backup from remote drive over SSH:
 

--- a/exclude.txt.example
+++ b/exclude.txt.example
@@ -1,0 +1,45 @@
+# Exclusiones básicas
+# ============================================
+# PRIMERO: Exclusiones recursivas globales
+# (DEBEN ir ANTES de los includes con ***)
+# ============================================
+- **/vendor
+- **/node_modules
+- **/.git
+- **/cache
+
+
+# Después incluye rutas específicas antes de excluir sus padres
++ /usr/
++ /usr/share/
++ /usr/share/zabbix/***
+
+- /usr/***
+- /var/***
++ /var/www/***
+- /proc/***
+- /sys/***
+- /dev/***
+- /tmp/***
+- /run/***
+- /mnt/***
+- /media/***
+- /cdrom/***
+- /lost+found/***
+- /snap/***
+- /opt/***
+- /srv/***
+- /boot/***
+- /bin/***
+- /sbin/***
+- /lib/***
+- /lib64/***
+- /lib32/***
+- /libx32/***
+
+# Inclusiones específicas
++ /home/***
++ /etc/***
++ /root/***
++ /backups/***
++ /backups_mysql/***

--- a/mcp-config.json
+++ b/mcp-config.json
@@ -1,0 +1,39 @@
+{
+  "mcpServers": {
+    "rsync-backup-files": {
+      "command": "npx",
+      "args": [
+        "@modelcontextprotocol/server-filesystem",
+        "."
+      ],
+      "description": "Archivos del proyecto rsync-time-backup"
+    },
+    "rsync-backup-git": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-git",
+        "--repository",
+        "."
+      ],
+      "description": "Git del proyecto rsync-time-backup"
+    },
+    "context7-remote": {
+      "command": "ssh",
+      "args": [
+        "abkrim@192.168.1.81",
+        "cd ~/mcp-servers/context7 && node node_modules/@upstash/context7-mcp/dist/index.js"
+      ],
+      "description": "Context7 - Documentación actualizada de código (Raspberry Pi)"
+    },
+    "mcp-supermemory-ai": {
+      "command": "npx",
+      "args": [
+          "-y",
+          "supergateway",
+          "--sse",
+          "https://mcp.supermemory.ai/m98Tuf_QRhzgZjxuP5HYY/sse"
+      ],
+      "description": "SuperMemory AI - Memoria extendida para contexto"
+    }
+  }
+}

--- a/project-config.json
+++ b/project-config.json
@@ -1,0 +1,22 @@
+{
+  "project_name": "rsync-time-backup",
+  "project_path": "/Users/abkrim/rsync-time-backup",
+  "client_type": "claude",
+  "features": {
+    "bash_scripting": true,
+    "backup_system": true,
+    "ssh_support": true,
+    "incremental_backup": true,
+    "expiration_strategies": true
+  },
+  "backup_config": {
+    "default_max_backups": 10,
+    "default_strategy": "1:1 30:7 365:30",
+    "requires_marker": true,
+    "supports_ssh": true
+  },
+  "script_type": "bash",
+  "main_script": "rsync_tmbackup.sh",
+  "created_at": "2025-07-06T07:13:37+02:00",
+  "mcp_isolated": true
+}

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -296,8 +296,9 @@ LOG_DIR="$HOME/.$APPNAME"
 AUTO_DELETE_LOG="1"
 EXPIRATION_STRATEGY="1:1 30:7 365:30"
 AUTO_EXPIRE="1"
+## --perms --owner --group remove form flags
+RSYNC_FLAGS="-D --numeric-ids --links --hard-links --one-file-system --itemize-changes --times --recursive --stats --human-readable"
 
-RSYNC_FLAGS="-D --numeric-ids --links --hard-links --one-file-system --itemize-changes --times --recursive --perms --owner --group --stats --human-readable"
 MAX_BACKUPS="10"
 
 while :; do

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -10,11 +10,11 @@ fn_log_info()  { echo "$APPNAME: $1"; }
 fn_log_warn()  { echo "$APPNAME: [WARNING] $1" 1>&2; }
 fn_log_error() { echo "$APPNAME: [ERROR] $1" 1>&2; }
 fn_log_info_cmd()  {
-	if [ -n "$SSH_DEST_FOLDER_PREFIX" ]; then
-		echo "$APPNAME: $SSH_CMD '$1'";
-	else
-		echo "$APPNAME: $1";
-	fi
+        if [ -n "$SSH_DEST_FOLDER_PREFIX" ]; then
+                echo "$APPNAME: $SSH_CMD '$1'";
+        else
+                echo "$APPNAME: $1";
+        fi
 }
 
 # -----------------------------------------------------------------------------
@@ -22,241 +22,258 @@ fn_log_info_cmd()  {
 # -----------------------------------------------------------------------------
 
 fn_terminate_script() {
-	fn_log_info "SIGINT caught."
-	exit 1
+        fn_log_info "SIGINT caught."
+        exit 1
 }
 
 trap 'fn_terminate_script' SIGINT
 
 # -----------------------------------------------------------------------------
+# Prune backups byu number
+# -----------------------------------------------------------------------------
+fn_prune_backups() {
+    local backup_count=$(fn_find_backups | wc -l)
+
+    while [ "$backup_count" -gt "$MAX_BACKUPS" ]; do
+        local oldest_backup=$(fn_find_backups | tail -n 1)
+        fn_log_info "Pruning oldest backup: $oldest_backup"
+        fn_expire_backup "$oldest_backup"
+        backup_count=$(fn_find_backups | wc -l)
+    done
+}
+
+
+# -----------------------------------------------------------------------------
 # Small utility functions for reducing code duplication
 # -----------------------------------------------------------------------------
 fn_display_usage() {
-	echo "Usage: $(basename "$0") [OPTION]... <[USER@HOST:]SOURCE> <[USER@HOST:]DESTINATION> [exclude-pattern-file]"
-	echo ""
-	echo "Options"
-	echo " -p, --port             SSH port."
-	echo " -h, --help             Display this help message."
-	echo " -i, --id_rsa           Specify the private ssh key to use."
-	echo " --rsync-get-flags      Display the default rsync flags that are used for backup. If using remote"
-	echo "                        drive over SSH, --compress will be added."
-	echo " --rsync-set-flags      Set the rsync flags that are going to be used for backup."
-	echo " --rsync-append-flags   Append the rsync flags that are going to be used for backup."
-	echo " --log-dir              Set the log file directory. If this flag is set, generated files will"
-	echo "                        not be managed by the script - in particular they will not be"
-	echo "                        automatically deleted."
-	echo "                        Default: $LOG_DIR"
-	echo " --strategy             Set the expiration strategy. Default: \"1:1 30:7 365:30\" means after one"
-	echo "                        day, keep one backup per day. After 30 days, keep one backup every 7 days."
-	echo "                        After 365 days keep one backup every 30 days."
-	echo " --no-auto-expire       Disable automatically deleting backups when out of space. Instead an error"
-	echo "                        is logged, and the backup is aborted."
-	echo ""
-	echo "For more detailed help, please see the README file:"
-	echo ""
-	echo "https://github.com/laurent22/rsync-time-backup/blob/master/README.md"
+        echo "Usage: $(basename "$0") [OPTION]... <[USER@HOST:]SOURCE> <[USER@HOST:]DESTINATION> [exclude-pattern-file]"
+        echo ""
+        echo "Options"
+        echo " -p, --port             SSH port."
+        echo " -h, --help             Display this help message."
+        echo " -i, --id_rsa           Specify the private ssh key to use."
+        echo " --rsync-get-flags      Display the default rsync flags that are used for backup. If using remote"
+        echo "                        drive over SSH, --compress will be added."
+        echo " --rsync-set-flags      Set the rsync flags that are going to be used for backup."
+        echo " --rsync-append-flags   Append the rsync flags that are going to be used for backup."
+        echo " --log-dir              Set the log file directory. If this flag is set, generated files will"
+        echo "                        not be managed by the script - in particular they will not be"
+        echo "                        automatically deleted."
+        echo "                        Default: $LOG_DIR"
+        echo " --strategy             Set the expiration strategy. Default: \"1:1 30:7 365:30\" means after one"
+        echo "                        day, keep one backup per day. After 30 days, keep one backup every 7 days."
+        echo "                        After 365 days keep one backup every 30 days."
+        echo " --no-auto-expire       Disable automatically deleting backups when out of space. Instead an error"
+        echo "                        is logged, and the backup is aborted."
+        echo " -m, --max_backups N    Specify the maximum number of backups (default: 10)."
+        echo "                        After this script prune backups."
+        echo ""
+        echo "For more detailed help, please see the README file:"
+        echo ""
+        echo "https://gitlab.castris.com/root/rsync-time-backup"
 }
 
 fn_parse_date() {
-	# Converts YYYY-MM-DD-HHMMSS to YYYY-MM-DD HH:MM:SS and then to Unix Epoch.
-	case "$OSTYPE" in
-		linux*|cygwin*|netbsd*)
-			date -d "${1:0:10} ${1:11:2}:${1:13:2}:${1:15:2}" +%s ;;
-		FreeBSD*) date -j -f "%Y-%m-%d-%H%M%S" "$1" "+%s" ;;
-		darwin*)
-			# Under MacOS X Tiger
-			# Or with GNU 'coreutils' installed (by homebrew)
-			#   'date -j' doesn't work, so we do this:
-			yy=$(expr ${1:0:4})
-			mm=$(expr ${1:5:2} - 1)
-			dd=$(expr ${1:8:2})
-			hh=$(expr ${1:11:2})
-			mi=$(expr ${1:13:2})
-			ss=$(expr ${1:15:2})
-			perl -e 'use Time::Local; print timelocal('$ss','$mi','$hh','$dd','$mm','$yy'),"\n";' ;;
-	esac
+        # Converts YYYY-MM-DD-HHMMSS to YYYY-MM-DD HH:MM:SS and then to Unix Epoch.
+        case "$OSTYPE" in
+                linux*|cygwin*|netbsd*)
+                        date -d "${1:0:10} ${1:11:2}:${1:13:2}:${1:15:2}" +%s ;;
+                FreeBSD*) date -j -f "%Y-%m-%d-%H%M%S" "$1" "+%s" ;;
+                darwin*)
+                        # Under MacOS X Tiger
+                        # Or with GNU 'coreutils' installed (by homebrew)
+                        #   'date -j' doesn't work, so we do this:
+                        yy=$(expr ${1:0:4})
+                        mm=$(expr ${1:5:2} - 1)
+                        dd=$(expr ${1:8:2})
+                        hh=$(expr ${1:11:2})
+                        mi=$(expr ${1:13:2})
+                        ss=$(expr ${1:15:2})
+                        perl -e 'use Time::Local; print timelocal('$ss','$mi','$hh','$dd','$mm','$yy'),"\n";' ;;
+        esac
 }
 
 fn_find_backups() {
-	fn_run_cmd "find "$DEST_FOLDER/" -maxdepth 1 -type d -name \"????-??-??-??????\" -prune | sort -r"
+        fn_run_cmd "find "$DEST_FOLDER/" -maxdepth 1 -type d -name \"????-??-??-??????\" -prune | sort -r"
 }
 
 fn_expire_backup() {
-	# Double-check that we're on a backup destination to be completely
-	# sure we're deleting the right folder
-	if [ -z "$(fn_find_backup_marker "$(dirname -- "$1")")" ]; then
-		fn_log_error "$1 is not on a backup destination - aborting."
-		exit 1
-	fi
+        # Double-check that we're on a backup destination to be completely
+        # sure we're deleting the right folder
+        if [ -z "$(fn_find_backup_marker "$(dirname -- "$1")")" ]; then
+                fn_log_error "$1 is not on a backup destination - aborting."
+                exit 1
+        fi
 
-	fn_log_info "Expiring $1"
-	fn_rm_dir "$1"
+        fn_log_info "Expiring $1"
+        fn_rm_dir "$1"
 }
 
 fn_expire_backups() {
-	local current_timestamp=$EPOCH
-	local last_kept_timestamp=9999999999
+        local current_timestamp=$EPOCH
+        local last_kept_timestamp=9999999999
 
-	# we will keep requested backup
-	backup_to_keep="$1"
-	# we will also keep the oldest backup
-	oldest_backup_to_keep="$(fn_find_backups | sort | sed -n '1p')"
+        # we will keep requested backup
+        backup_to_keep="$1"
+        # we will also keep the oldest backup
+        oldest_backup_to_keep="$(fn_find_backups | sort | sed -n '1p')"
 
-	# Process each backup dir from the oldest to the most recent
-	for backup_dir in $(fn_find_backups | sort); do
+        # Process each backup dir from the oldest to the most recent
+        for backup_dir in $(fn_find_backups | sort); do
 
-		local backup_date=$(basename "$backup_dir")
-		local backup_timestamp=$(fn_parse_date "$backup_date")
+                local backup_date=$(basename "$backup_dir")
+                local backup_timestamp=$(fn_parse_date "$backup_date")
 
-		# Skip if failed to parse date...
-		if [ -z "$backup_timestamp" ]; then
-			fn_log_warn "Could not parse date: $backup_dir"
-			continue
-		fi
+                # Skip if failed to parse date...
+                if [ -z "$backup_timestamp" ]; then
+                        fn_log_warn "Could not parse date: $backup_dir"
+                        continue
+                fi
 
-		if [ "$backup_dir" == "$backup_to_keep" ]; then
-			# this is the latest backup requsted to be kept. We can finish pruning
-			break
-		fi
+                if [ "$backup_dir" == "$backup_to_keep" ]; then
+                        # this is the latest backup requsted to be kept. We can finish pruning
+                        break
+                fi
 
-		if [ "$backup_dir" == "$oldest_backup_to_keep" ]; then
-			# We dont't want to delete the oldest backup. It becomes first "last kept" backup
-			last_kept_timestamp=$backup_timestamp
-			# As we keep it we can skip processing it and go to the next oldest one in the loop
-			continue
-		fi
+                if [ "$backup_dir" == "$oldest_backup_to_keep" ]; then
+                        # We dont't want to delete the oldest backup. It becomes first "last kept" backup
+                        last_kept_timestamp=$backup_timestamp
+                        # As we keep it we can skip processing it and go to the next oldest one in the loop
+                        continue
+                fi
 
-		# Find which strategy token applies to this particular backup
-		for strategy_token in $(echo $EXPIRATION_STRATEGY | tr " " "\n" | sort -r -n); do
-			IFS=':' read -r -a t <<< "$strategy_token"
+                # Find which strategy token applies to this particular backup
+                for strategy_token in $(echo $EXPIRATION_STRATEGY | tr " " "\n" | sort -r -n); do
+                        IFS=':' read -r -a t <<< "$strategy_token"
 
-			# After which date (relative to today) this token applies (X) - we use seconds to get exact cut off time
-			local cut_off_timestamp=$((current_timestamp - ${t[0]} * 86400))
+                        # After which date (relative to today) this token applies (X) - we use seconds to get exact cut off time
+                        local cut_off_timestamp=$((current_timestamp - ${t[0]} * 86400))
 
-			# Every how many days should a backup be kept past the cut off date (Y) - we use days (not seconds)
-			local cut_off_interval_days=$((${t[1]}))
+                        # Every how many days should a backup be kept past the cut off date (Y) - we use days (not seconds)
+                        local cut_off_interval_days=$((${t[1]}))
 
-			# If we've found the strategy token that applies to this backup
-			if [ "$backup_timestamp" -le "$cut_off_timestamp" ]; then
+                        # If we've found the strategy token that applies to this backup
+                        if [ "$backup_timestamp" -le "$cut_off_timestamp" ]; then
 
-				# Special case: if Y is "0" we delete every time
-				if [ $cut_off_interval_days -eq "0" ]; then
-					fn_expire_backup "$backup_dir"
-					break
-				fi
+                                # Special case: if Y is "0" we delete every time
+                                if [ $cut_off_interval_days -eq "0" ]; then
+                                        fn_expire_backup "$backup_dir"
+                                        break
+                                fi
 
-				# we calculate days number since last kept backup
-				local last_kept_timestamp_days=$((last_kept_timestamp / 86400))
-				local backup_timestamp_days=$((backup_timestamp / 86400))
-				local interval_since_last_kept_days=$((backup_timestamp_days - last_kept_timestamp_days))
+                                # we calculate days number since last kept backup
+                                local last_kept_timestamp_days=$((last_kept_timestamp / 86400))
+                                local backup_timestamp_days=$((backup_timestamp / 86400))
+                                local interval_since_last_kept_days=$((backup_timestamp_days - last_kept_timestamp_days))
 
-				# Check if the current backup is in the interval between
-				# the last backup that was kept and Y
-				# to determine what to keep/delete we use days difference
-				if [ "$interval_since_last_kept_days" -lt "$cut_off_interval_days" ]; then
+                                # Check if the current backup is in the interval between
+                                # the last backup that was kept and Y
+                                # to determine what to keep/delete we use days difference
+                                if [ "$interval_since_last_kept_days" -lt "$cut_off_interval_days" ]; then
 
-					# Yes: Delete that one
-					fn_expire_backup "$backup_dir"
-					# backup deleted no point to check shorter timespan strategies - go to the next backup
-					break
+                                        # Yes: Delete that one
+                                        fn_expire_backup "$backup_dir"
+                                        # backup deleted no point to check shorter timespan strategies - go to the next backup
+                                        break
 
-				else
+                                else
 
-					# No: Keep it.
-					# this is now the last kept backup
-					last_kept_timestamp=$backup_timestamp
-					# and go to the next backup
-					break
-				fi
-			fi
-		done
-	done
+                                        # No: Keep it.
+                                        # this is now the last kept backup
+                                        last_kept_timestamp=$backup_timestamp
+                                        # and go to the next backup
+                                        break
+                                fi
+                        fi
+                done
+        done
 }
 
 fn_parse_ssh() {
-	# To keep compatibility with bash version < 3, we use grep
-	if echo "$DEST_FOLDER"|grep -Eq '^[A-Za-z0-9\._%\+\-]+@[A-Za-z0-9.\-]+\:.+$'
-	then
-		SSH_USER=$(echo "$DEST_FOLDER" | sed -E  's/^([A-Za-z0-9\._%\+\-]+)@([A-Za-z0-9.\-]+)\:(.+)$/\1/')
-		SSH_HOST=$(echo "$DEST_FOLDER" | sed -E  's/^([A-Za-z0-9\._%\+\-]+)@([A-Za-z0-9.\-]+)\:(.+)$/\2/')
-		SSH_DEST_FOLDER=$(echo "$DEST_FOLDER" | sed -E  's/^([A-Za-z0-9\._%\+\-]+)@([A-Za-z0-9.\-]+)\:(.+)$/\3/')
-		if [ -n "$ID_RSA" ] ; then
-			SSH_CMD="ssh -p $SSH_PORT -i $ID_RSA ${SSH_USER}@${SSH_HOST}"
-		else
-			SSH_CMD="ssh -p $SSH_PORT ${SSH_USER}@${SSH_HOST}"
-		fi
-		SSH_DEST_FOLDER_PREFIX="${SSH_USER}@${SSH_HOST}:"
-	elif echo "$SRC_FOLDER"|grep -Eq '^[A-Za-z0-9\._%\+\-]+@[A-Za-z0-9.\-]+\:.+$'
-	then
-		SSH_USER=$(echo "$SRC_FOLDER" | sed -E  's/^([A-Za-z0-9\._%\+\-]+)@([A-Za-z0-9.\-]+)\:(.+)$/\1/')
-		SSH_HOST=$(echo "$SRC_FOLDER" | sed -E  's/^([A-Za-z0-9\._%\+\-]+)@([A-Za-z0-9.\-]+)\:(.+)$/\2/')
-		SSH_SRC_FOLDER=$(echo "$SRC_FOLDER" | sed -E  's/^([A-Za-z0-9\._%\+\-]+)@([A-Za-z0-9.\-]+)\:(.+)$/\3/')
-		if [ -n "$ID_RSA" ] ; then
-			SSH_CMD="ssh -p $SSH_PORT -i $ID_RSA ${SSH_USER}@${SSH_HOST}"
-		else
-			SSH_CMD="ssh -p $SSH_PORT ${SSH_USER}@${SSH_HOST}"
-		fi
-		SSH_SRC_FOLDER_PREFIX="${SSH_USER}@${SSH_HOST}:"
-	fi
+        # To keep compatibility with bash version < 3, we use grep
+        if echo "$DEST_FOLDER"|grep -Eq '^[A-Za-z0-9\._%\+\-]+@[A-Za-z0-9.\-]+\:.+$'
+        then
+                SSH_USER=$(echo "$DEST_FOLDER" | sed -E  's/^([A-Za-z0-9\._%\+\-]+)@([A-Za-z0-9.\-]+)\:(.+)$/\1/')
+                SSH_HOST=$(echo "$DEST_FOLDER" | sed -E  's/^([A-Za-z0-9\._%\+\-]+)@([A-Za-z0-9.\-]+)\:(.+)$/\2/')
+                SSH_DEST_FOLDER=$(echo "$DEST_FOLDER" | sed -E  's/^([A-Za-z0-9\._%\+\-]+)@([A-Za-z0-9.\-]+)\:(.+)$/\3/')
+                if [ -n "$ID_RSA" ] ; then
+                        SSH_CMD="ssh -p $SSH_PORT -i $ID_RSA ${SSH_USER}@${SSH_HOST}"
+                else
+                        SSH_CMD="ssh -p $SSH_PORT ${SSH_USER}@${SSH_HOST}"
+                fi
+                SSH_DEST_FOLDER_PREFIX="${SSH_USER}@${SSH_HOST}:"
+        elif echo "$SRC_FOLDER"|grep -Eq '^[A-Za-z0-9\._%\+\-]+@[A-Za-z0-9.\-]+\:.+$'
+        then
+                SSH_USER=$(echo "$SRC_FOLDER" | sed -E  's/^([A-Za-z0-9\._%\+\-]+)@([A-Za-z0-9.\-]+)\:(.+)$/\1/')
+                SSH_HOST=$(echo "$SRC_FOLDER" | sed -E  's/^([A-Za-z0-9\._%\+\-]+)@([A-Za-z0-9.\-]+)\:(.+)$/\2/')
+                SSH_SRC_FOLDER=$(echo "$SRC_FOLDER" | sed -E  's/^([A-Za-z0-9\._%\+\-]+)@([A-Za-z0-9.\-]+)\:(.+)$/\3/')
+                if [ -n "$ID_RSA" ] ; then
+                        SSH_CMD="ssh -p $SSH_PORT -i $ID_RSA ${SSH_USER}@${SSH_HOST}"
+                else
+                        SSH_CMD="ssh -p $SSH_PORT ${SSH_USER}@${SSH_HOST}"
+                fi
+                SSH_SRC_FOLDER_PREFIX="${SSH_USER}@${SSH_HOST}:"
+        fi
 }
 
 fn_run_cmd() {
-	if [ -n "$SSH_DEST_FOLDER_PREFIX" ]
-	then
-		eval "$SSH_CMD '$1'"
-	else
-		eval $1
-	fi
+        if [ -n "$SSH_DEST_FOLDER_PREFIX" ]
+        then
+                eval "$SSH_CMD '$1'"
+        else
+                eval $1
+        fi
 }
 
 fn_run_cmd_src() {
-	if [ -n "$SSH_SRC_FOLDER_PREFIX" ]
-	then
-		eval "$SSH_CMD '$1'"
-	else
-		eval $1
-	fi
+        if [ -n "$SSH_SRC_FOLDER_PREFIX" ]
+        then
+                eval "$SSH_CMD '$1'"
+        else
+                eval $1
+        fi
 }
 
 fn_find() {
-	fn_run_cmd "find '$1'"  2>/dev/null
+        fn_run_cmd "find '$1'"  2>/dev/null
 }
 
 fn_get_absolute_path() {
-	fn_run_cmd "cd '$1';pwd"
+        fn_run_cmd "cd '$1';pwd"
 }
 
 fn_mkdir() {
-	fn_run_cmd "mkdir -p -- '$1'"
+        fn_run_cmd "mkdir -p -- '$1'"
 }
 
 # Removes a file or symlink - not for directories
 fn_rm_file() {
-	fn_run_cmd "rm -f -- '$1'"
+        fn_run_cmd "rm -f -- '$1'"
 }
 
 fn_rm_dir() {
-	fn_run_cmd "rm -rf -- '$1'"
+        fn_run_cmd "rm -rf -- '$1'"
 }
 
 fn_touch() {
-	fn_run_cmd "touch -- '$1'"
+        fn_run_cmd "touch -- '$1'"
 }
 
 fn_ln() {
-	fn_run_cmd "ln -s -- '$1' '$2'"
+        fn_run_cmd "ln -s -- '$1' '$2'"
 }
 
 fn_test_file_exists_src() {
-	fn_run_cmd_src "test -e '$1'"
+        fn_run_cmd_src "test -e '$1'"
 }
 
 fn_df_t_src() {
-	fn_run_cmd_src "df -T '${1}'"
+        fn_run_cmd_src "df -T '${1}'"
 }
 
 fn_df_t() {
-	fn_run_cmd "df -T '${1}'"
+        fn_run_cmd "df -T '${1}'"
 }
 
 # -----------------------------------------------------------------------------
@@ -281,73 +298,78 @@ EXPIRATION_STRATEGY="1:1 30:7 365:30"
 AUTO_EXPIRE="1"
 
 RSYNC_FLAGS="-D --numeric-ids --links --hard-links --one-file-system --itemize-changes --times --recursive --perms --owner --group --stats --human-readable"
+MAX_BACKUPS="10"
 
 while :; do
-	case $1 in
-		-h|-\?|--help)
-			fn_display_usage
-			exit
-			;;
-		-p|--port)
-			shift
-			SSH_PORT=$1
-			;;
-		-i|--id_rsa)
-			shift
-			ID_RSA="$1"
-			;;
-		--rsync-get-flags)
-			shift
-			echo "$RSYNC_FLAGS"
-			exit
-			;;
-		--rsync-set-flags)
-			shift
-			RSYNC_FLAGS="$1"
-			;;
-		--rsync-append-flags)
-			shift
-			RSYNC_FLAGS="$RSYNC_FLAGS $1"
-			;;
-		--strategy)
-			shift
-			EXPIRATION_STRATEGY="$1"
-			;;
-		--log-dir)
-			shift
-			LOG_DIR="$1"
-			AUTO_DELETE_LOG="0"
-			;;
-		--no-auto-expire)
-			AUTO_EXPIRE="0"
-			;;
-		--)
-			shift
-			SRC_FOLDER="$1"
-			DEST_FOLDER="$2"
-			EXCLUSION_FILE="$3"
-			break
-			;;
-		-*)
-			fn_log_error "Unknown option: \"$1\""
-			fn_log_info ""
-			fn_display_usage
-			exit 1
-			;;
-		*)
-			SRC_FOLDER="$1"
-			DEST_FOLDER="$2"
-			EXCLUSION_FILE="$3"
-			break
-	esac
+        case $1 in
+                -h|-\?|--help)
+                        fn_display_usage
+                        exit
+                        ;;
+                -p|--port)
+                        shift
+                        SSH_PORT=$1
+                        ;;
+                -i|--id_rsa)
+                        shift
+                        ID_RSA="$1"
+                        ;;
+                -m|--max_backups)
+                        shift
+                        MAX_BACKUPS="$1"
+                        ;;
+                --rsync-get-flags)
+                        shift
+                        echo "$RSYNC_FLAGS"
+                        exit
+                        ;;
+                --rsync-set-flags)
+                        shift
+                        RSYNC_FLAGS="$1"
+                        ;;
+                --rsync-append-flags)
+                        shift
+                        RSYNC_FLAGS="$RSYNC_FLAGS $1"
+                        ;;
+                --strategy)
+                        shift
+                        EXPIRATION_STRATEGY="$1"
+                        ;;
+                --log-dir)
+                        shift
+                        LOG_DIR="$1"
+                        AUTO_DELETE_LOG="0"
+                        ;;
+                --no-auto-expire)
+                        AUTO_EXPIRE="0"
+                        ;;
+                --)
+                        shift
+                        SRC_FOLDER="$1"
+                        DEST_FOLDER="$2"
+                        EXCLUSION_FILE="$3"
+                        break
+                        ;;
+                -*)
+                        fn_log_error "Unknown option: \"$1\""
+                        fn_log_info ""
+                        fn_display_usage
+                        exit 1
+                        ;;
+                *)
+                        SRC_FOLDER="$1"
+                        DEST_FOLDER="$2"
+                        EXCLUSION_FILE="$3"
+                        break
+        esac
 
-	shift
+        shift
 done
 
 # Display usage information if required arguments are not passed
 if [[ -z "$SRC_FOLDER" || -z "$DEST_FOLDER" ]]; then
-	fn_display_usage
-	exit 1
+        fn_display_usage
+        exit 1
 fi
 
 # Strips off last slash from dest. Note that it means the root folder "/"
@@ -362,27 +384,27 @@ DEST_FOLDER="${DEST_FOLDER%/}"
 fn_parse_ssh
 
 if [ -n "$SSH_DEST_FOLDER" ]; then
-	DEST_FOLDER="$SSH_DEST_FOLDER"
+        DEST_FOLDER="$SSH_DEST_FOLDER"
 fi
 
 if [ -n "$SSH_SRC_FOLDER" ]; then
-	SRC_FOLDER="$SSH_SRC_FOLDER"
+        SRC_FOLDER="$SSH_SRC_FOLDER"
 fi
 
 # Exit if source folder does not exist.
 if ! fn_test_file_exists_src "${SRC_FOLDER}"; then
-	fn_log_error "Source folder \"${SRC_FOLDER}\" does not exist - aborting."
-	exit 1
+        fn_log_error "Source folder \"${SRC_FOLDER}\" does not exist - aborting."
+        exit 1
 fi
 
 # Now strip off last slash from source folder.
 SRC_FOLDER="${SRC_FOLDER%/}"
 
 for ARG in "$SRC_FOLDER" "$DEST_FOLDER" "$EXCLUSION_FILE"; do
-	if [[ "$ARG" == *"'"* ]]; then
-		fn_log_error 'Source and destination directories may not contain single quote characters.'
-		exit 1
-	fi
+        if [[ "$ARG" == *"'"* ]]; then
+                fn_log_error 'Source and destination directories may not contain single quote characters.'
+                exit 1
+        fi
 done
 
 # -----------------------------------------------------------------------------
@@ -395,12 +417,12 @@ fn_backup_marker_path() { echo "$1/backup.marker"; }
 fn_find_backup_marker() { fn_find "$(fn_backup_marker_path "$1")" 2>/dev/null; }
 
 if [ -z "$(fn_find_backup_marker "$DEST_FOLDER")" ]; then
-	fn_log_info "Safety check failed - the destination does not appear to be a backup folder or drive (marker file not found)."
-	fn_log_info "If it is indeed a backup folder, you may add the marker file by running the following command:"
-	fn_log_info ""
-	fn_log_info_cmd "mkdir -p -- \"$DEST_FOLDER\" ; touch \"$(fn_backup_marker_path "$DEST_FOLDER")\""
-	fn_log_info ""
-	exit 1
+        fn_log_info "Safety check failed - the destination does not appear to be a backup folder or drive (marker file not found)."
+        fn_log_info "If it is indeed a backup folder, you may add the marker file by running the following command:"
+        fn_log_info ""
+        fn_log_info_cmd "mkdir -p -- \"$DEST_FOLDER\" ; touch \"$(fn_backup_marker_path "$DEST_FOLDER")\""
+        fn_log_info ""
+        exit 1
 fi
 
 # Check source and destination file-system (df -T /dest).
@@ -410,13 +432,13 @@ fi
 # The check is performed by taking the second row
 # of the output of the first command.
 if [[ "$(fn_df_t_src "${SRC_FOLDER}" | awk '{print $2}' | grep -c -i -e "fat")" -gt 0 ]]; then
-	fn_log_info "Source file-system is a version of FAT."
-	fn_log_info "Using the --modify-window rsync parameter with value 2."
-	RSYNC_FLAGS="${RSYNC_FLAGS} --modify-window=2"
+        fn_log_info "Source file-system is a version of FAT."
+        fn_log_info "Using the --modify-window rsync parameter with value 2."
+        RSYNC_FLAGS="${RSYNC_FLAGS} --modify-window=2"
 elif [[ "$(fn_df_t "${DEST_FOLDER}" | awk '{print $2}' | grep -c -i -e "fat")" -gt 0 ]]; then
-	fn_log_info "Destination file-system is a version of FAT."
-	fn_log_info "Using the --modify-window rsync parameter with value 2."
-	RSYNC_FLAGS="${RSYNC_FLAGS} --modify-window=2"
+        fn_log_info "Destination file-system is a version of FAT."
+        fn_log_info "Using the --modify-window rsync parameter with value 2."
+        RSYNC_FLAGS="${RSYNC_FLAGS} --modify-window=2"
 fi
 
 # -----------------------------------------------------------------------------
@@ -440,8 +462,8 @@ MYPID="$$"
 # -----------------------------------------------------------------------------
 
 if [ ! -d "$LOG_DIR" ]; then
-	fn_log_info "Creating log folder in '$LOG_DIR'..."
-	mkdir -- "$LOG_DIR"
+        fn_log_info "Creating log folder in '$LOG_DIR'..."
+        mkdir -- "$LOG_DIR"
 fi
 
 # -----------------------------------------------------------------------------
@@ -449,178 +471,194 @@ fi
 # -----------------------------------------------------------------------------
 
 if [ -n "$(fn_find "$INPROGRESS_FILE")" ]; then
-	if [ "$OSTYPE" == "cygwin" ]; then
-		# 1. Grab the PID of previous run from the PID file
-		RUNNINGPID="$(fn_run_cmd "cat $INPROGRESS_FILE")"
+        if [ "$OSTYPE" == "cygwin" ]; then
+                # 1. Grab the PID of previous run from the PID file
+                RUNNINGPID="$(fn_run_cmd "cat $INPROGRESS_FILE")"
 
-		# 2. Get the command for the process currently running under that PID and look for our script name
-		RUNNINGCMD="$(procps -wwfo cmd -p $RUNNINGPID --no-headers | grep "$APPNAME")"
+                # 2. Get the command for the process currently running under that PID and look for our script name
+                RUNNINGCMD="$(procps -wwfo cmd -p $RUNNINGPID --no-headers | grep "$APPNAME")"
 
-		# 3. Grab the exit code from grep (0=found, 1=not found)
-		GREPCODE=$?
+                # 3. Grab the exit code from grep (0=found, 1=not found)
+                GREPCODE=$?
 
-		# 4. if found, assume backup is still running
-		if [ "$GREPCODE" = 0 ]; then
-			fn_log_error "Previous backup task is still active - aborting (command: $RUNNINGCMD)."
-			exit 1
-		fi
-	elif [[ "$OSTYPE" == "netbsd"* ]]; then
-		RUNNINGPID="$(fn_run_cmd "cat $INPROGRESS_FILE")"
-		if ps -axp "$RUNNINGPID" -o "command" | grep "$APPNAME" > /dev/null; then
-			fn_log_error "Previous backup task is still active - aborting."
-			exit 1
-		fi
-	else
-		RUNNINGPID="$(fn_run_cmd "cat $INPROGRESS_FILE")"
-		if ps -p "$RUNNINGPID" -o command | grep "$APPNAME"
-		then
-			fn_log_error "Previous backup task is still active - aborting."
-			exit 1
-		fi
-	fi
+                # 4. if found, assume backup is still running
+                if [ "$GREPCODE" = 0 ]; then
+                        fn_log_error "Previous backup task is still active - aborting (command: $RUNNINGCMD)."
+                        exit 1
+                fi
+        elif [[ "$OSTYPE" == "netbsd"* ]]; then
+                RUNNINGPID="$(fn_run_cmd "cat $INPROGRESS_FILE")"
+                if ps -axp "$RUNNINGPID" -o "command" | grep "$APPNAME" > /dev/null; then
+                        fn_log_error "Previous backup task is still active - aborting."
+                        exit 1
+                fi
+        else
+                RUNNINGPID="$(fn_run_cmd "cat $INPROGRESS_FILE")"
+                if ps -p "$RUNNINGPID" -o command | grep "$APPNAME"
+                then
+                        fn_log_error "Previous backup task is still active - aborting."
+                        exit 1
+                fi
+        fi
 
-	if [ -n "$PREVIOUS_DEST" ]; then
-		# - Last backup is moved to current backup folder so that it can be resumed.
-		# - 2nd to last backup becomes last backup.
-		fn_log_info "$SSH_DEST_FOLDER_PREFIX$INPROGRESS_FILE already exists - the previous backup failed or was interrupted. Backup will resume from there."
-		fn_run_cmd "mv -- $PREVIOUS_DEST $DEST"
-		if [ "$(fn_find_backups | wc -l)" -gt 1 ]; then
-			PREVIOUS_DEST="$(fn_find_backups | sed -n '2p')"
-		else
-			PREVIOUS_DEST=""
-		fi
-		# update PID to current process to avoid multiple concurrent resumes
-		fn_run_cmd "echo $MYPID > $INPROGRESS_FILE"
-	fi
+        if [ -n "$PREVIOUS_DEST" ]; then
+                # - Last backup is moved to current backup folder so that it can be resumed.
+                # - 2nd to last backup becomes last backup.
+                fn_log_info "$SSH_DEST_FOLDER_PREFIX$INPROGRESS_FILE already exists - the previous backup failed or was interrupted. Backup will resume from there."
+                fn_run_cmd "mv -- $PREVIOUS_DEST $DEST"
+                if [ "$(fn_find_backups | wc -l)" -gt 1 ]; then
+                        PREVIOUS_DEST="$(fn_find_backups | sed -n '2p')"
+                else
+                        PREVIOUS_DEST=""
+                fi
+                # update PID to current process to avoid multiple concurrent resumes
+                fn_run_cmd "echo $MYPID > $INPROGRESS_FILE"
+        fi
 fi
+
 
 # Run in a loop to handle the "No space left on device" logic.
 while : ; do
 
-	# -----------------------------------------------------------------------------
-	# Check if we are doing an incremental backup (if previous backup exists).
-	# -----------------------------------------------------------------------------
+        # -----------------------------------------------------------------------------
+        # Check if we are doing an incremental backup (if previous backup exists).
+        # -----------------------------------------------------------------------------
 
-	LINK_DEST_OPTION=""
-	if [ -z "$PREVIOUS_DEST" ]; then
-		fn_log_info "No previous backup - creating new one."
-	else
-		# If the path is relative, it needs to be relative to the destination. To keep
-		# it simple, just use an absolute path. See http://serverfault.com/a/210058/118679
-		PREVIOUS_DEST="$(fn_get_absolute_path "$PREVIOUS_DEST")"
-		fn_log_info "Previous backup found - doing incremental backup from $SSH_DEST_FOLDER_PREFIX$PREVIOUS_DEST"
-		LINK_DEST_OPTION="--link-dest='$PREVIOUS_DEST'"
-	fi
+        LINK_DEST_OPTION=""
+        if [ -z "$PREVIOUS_DEST" ]; then
+                fn_log_info "No previous backup - creating new one."
+        else
+                # If the path is relative, it needs to be relative to the destination. To keep
+                # it simple, just use an absolute path. See http://serverfault.com/a/210058/118679
+                PREVIOUS_DEST="$(fn_get_absolute_path "$PREVIOUS_DEST")"
+                fn_log_info "Previous backup found - doing incremental backup from $SSH_DEST_FOLDER_PREFIX$PREVIOUS_DEST"
+                LINK_DEST_OPTION="--link-dest='$PREVIOUS_DEST'"
+        fi
 
-	# -----------------------------------------------------------------------------
-	# Create destination folder if it doesn't already exists
-	# -----------------------------------------------------------------------------
+        # -----------------------------------------------------------------------------
+        # Create destination folder if it doesn't already exists
+        # -----------------------------------------------------------------------------
 
-	if [ -z "$(fn_find "$DEST -type d" 2>/dev/null)" ]; then
-		fn_log_info "Creating destination $SSH_DEST_FOLDER_PREFIX$DEST"
-		fn_mkdir "$DEST"
-	fi
+        if [ -z "$(fn_find "$DEST -type d" 2>/dev/null)" ]; then
+                fn_log_info "Creating destination $SSH_DEST_FOLDER_PREFIX$DEST"
+                fn_mkdir "$DEST"
+        fi
 
-	# -----------------------------------------------------------------------------
-	# Purge certain old backups before beginning new backup.
-	# -----------------------------------------------------------------------------
+        # -----------------------------------------------------------------------------
+        # Purge certain old backups before beginning new backup.
+        # -----------------------------------------------------------------------------
 
-	if [ -n "$PREVIOUS_DEST" ]; then
-		# regardless of expiry strategy keep backup used for --link-dest
-		fn_expire_backups "$PREVIOUS_DEST"
-	else
-		# keep latest backup
-		fn_expire_backups "$DEST"
-	fi
+        if [ -n "$PREVIOUS_DEST" ]; then
+                # regardless of expiry strategy keep backup used for --link-dest
+                fn_expire_backups "$PREVIOUS_DEST"
+        else
+                # keep latest backup
+                fn_expire_backups "$DEST"
+        fi
 
-	# -----------------------------------------------------------------------------
-	# Start backup
-	# -----------------------------------------------------------------------------
+        # -----------------------------------------------------------------------------
+        # Purge certain old backups before beginning new backup.
+        # -----------------------------------------------------------------------------
 
-	LOG_FILE="$LOG_DIR/$(date +"%Y-%m-%d-%H%M%S").log"
+        # Llamar a la función de pruning basado en cantidad antes de iniciar el backup.
+        fn_prune_backups
 
-	fn_log_info "Starting backup..."
-	fn_log_info "From: $SSH_SRC_FOLDER_PREFIX$SRC_FOLDER/"
-	fn_log_info "To:   $SSH_DEST_FOLDER_PREFIX$DEST/"
 
-	CMD="rsync"
-	if [ -n "$SSH_CMD" ]; then
-		RSYNC_FLAGS="$RSYNC_FLAGS --compress"
-		if [ -n "$ID_RSA" ] ; then
-			CMD="$CMD  -e 'ssh -p $SSH_PORT -i $ID_RSA -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'"
-		else
-			CMD="$CMD  -e 'ssh -p $SSH_PORT -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'"
-		fi
-	fi
-	CMD="$CMD $RSYNC_FLAGS"
-	CMD="$CMD --log-file '$LOG_FILE'"
-	if [ -n "$EXCLUSION_FILE" ]; then
-		# We've already checked that $EXCLUSION_FILE doesn't contain a single quote
-		CMD="$CMD --exclude-from '$EXCLUSION_FILE'"
-	fi
-	CMD="$CMD $LINK_DEST_OPTION"
-	CMD="$CMD -- '$SSH_SRC_FOLDER_PREFIX$SRC_FOLDER/' '$SSH_DEST_FOLDER_PREFIX$DEST/'"
 
-	fn_log_info "Running command:"
-	fn_log_info "$CMD"
+        if [ -n "$PREVIOUS_DEST" ]; then
+                fn_expire_backups "$PREVIOUS_DEST"
+        else
+                fn_expire_backups "$DEST"
+        fi
 
-	fn_run_cmd "echo $MYPID > $INPROGRESS_FILE"
-	eval $CMD
+        # -----------------------------------------------------------------------------
+        # Start backup
+        # -----------------------------------------------------------------------------
 
-	# -----------------------------------------------------------------------------
-	# Check if we ran out of space
-	# -----------------------------------------------------------------------------
+        LOG_FILE="$LOG_DIR/$(date +"%Y-%m-%d-%H%M%S").log"
 
-	NO_SPACE_LEFT="$(grep "No space left on device (28)\|Result too large (34)" "$LOG_FILE")"
+        fn_log_info "Starting backup..."
+        fn_log_info "From: $SSH_SRC_FOLDER_PREFIX$SRC_FOLDER/"
+        fn_log_info "To:   $SSH_DEST_FOLDER_PREFIX$DEST/"
 
-	if [ -n "$NO_SPACE_LEFT" ]; then
+        CMD="rsync"
+        if [ -n "$SSH_CMD" ]; then
+                RSYNC_FLAGS="$RSYNC_FLAGS --compress"
+                if [ -n "$ID_RSA" ] ; then
+                        CMD="$CMD  -e 'ssh -p $SSH_PORT -i $ID_RSA -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'"
+                else
+                        CMD="$CMD  -e 'ssh -p $SSH_PORT -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'"
+                fi
+        fi
+        CMD="$CMD $RSYNC_FLAGS"
+        CMD="$CMD --log-file '$LOG_FILE'"
+        if [ -n "$EXCLUSION_FILE" ]; then
+                # We've already checked that $EXCLUSION_FILE doesn't contain a single quote
+                CMD="$CMD --exclude-from '$EXCLUSION_FILE'"
+        fi
+        CMD="$CMD $LINK_DEST_OPTION"
+        CMD="$CMD -- '$SSH_SRC_FOLDER_PREFIX$SRC_FOLDER/' '$SSH_DEST_FOLDER_PREFIX$DEST/'"
 
-		if [[ $AUTO_EXPIRE == "0" ]]; then
-			fn_log_error "No space left on device, and automatic purging of old backups is disabled."
-			exit 1
-		fi
+        fn_log_info "Running command:"
+        fn_log_info "$CMD"
 
-		fn_log_warn "No space left on device - removing oldest backup and resuming."
+        fn_run_cmd "echo $MYPID > $INPROGRESS_FILE"
+        eval $CMD
 
-		if [[ "$(fn_find_backups | wc -l)" -lt "2" ]]; then
-			fn_log_error "No space left on device, and no old backup to delete."
-			exit 1
-		fi
+        # -----------------------------------------------------------------------------
+        # Check if we ran out of space
+        # -----------------------------------------------------------------------------
 
-		fn_expire_backup "$(fn_find_backups | tail -n 1)"
+        NO_SPACE_LEFT="$(grep "No space left on device (28)\|Result too large (34)" "$LOG_FILE")"
 
-		# Resume backup
-		continue
-	fi
+        if [ -n "$NO_SPACE_LEFT" ]; then
 
-	# -----------------------------------------------------------------------------
-	# Check whether rsync reported any errors
-	# -----------------------------------------------------------------------------
+                if [[ $AUTO_EXPIRE == "0" ]]; then
+                        fn_log_error "No space left on device, and automatic purging of old backups is disabled."
+                        exit 1
+                fi
 
-	EXIT_CODE="1"
-	if [ -n "$(grep "rsync error:" "$LOG_FILE")" ]; then
-		fn_log_error "Rsync reported an error. Run this command for more details: grep -E 'rsync:|rsync error:' '$LOG_FILE'"
-	elif [ -n "$(grep "rsync:" "$LOG_FILE")" ]; then
-		fn_log_warn "Rsync reported a warning. Run this command for more details: grep -E 'rsync:|rsync error:' '$LOG_FILE'"
-	else
-		fn_log_info "Backup completed without errors."
-		if [[ $AUTO_DELETE_LOG == "1" ]]; then
-			rm -f -- "$LOG_FILE"
-		fi
-		EXIT_CODE="0"
-	fi
+                fn_log_warn "No space left on device - removing oldest backup and resuming."
 
-	# -----------------------------------------------------------------------------
-	# Add symlink to last backup
-	# -----------------------------------------------------------------------------
-	if [ "$EXIT_CODE" = 0 ]; then
-		# Create the latest symlink only when rsync succeeded
-		fn_rm_file "$DEST_FOLDER/latest"
-		fn_ln "$(basename -- "$DEST")" "$DEST_FOLDER/latest"
+                if [[ "$(fn_find_backups | wc -l)" -lt "2" ]]; then
+                        fn_log_error "No space left on device, and no old backup to delete."
+                        exit 1
+                fi
 
-		# Remove .inprogress file only when rsync succeeded
-		fn_rm_file "$INPROGRESS_FILE"
-	fi
+                fn_expire_backup "$(fn_find_backups | tail -n 1)"
 
-	exit $EXIT_CODE
+                # Resume backup
+                continue
+        fi
+
+        # -----------------------------------------------------------------------------
+        # Check whether rsync reported any errors
+        # -----------------------------------------------------------------------------
+
+        EXIT_CODE="1"
+        if [ -n "$(grep "rsync error:" "$LOG_FILE")" ]; then
+                fn_log_error "Rsync reported an error. Run this command for more details: grep -E 'rsync:|rsync error:' '$LOG_FILE'"
+        elif [ -n "$(grep "rsync:" "$LOG_FILE")" ]; then
+                fn_log_warn "Rsync reported a warning. Run this command for more details: grep -E 'rsync:|rsync error:' '$LOG_FILE'"
+        else
+                fn_log_info "Backup completed without errors."
+                if [[ $AUTO_DELETE_LOG == "1" ]]; then
+                        rm -f -- "$LOG_FILE"
+                fi
+                EXIT_CODE="0"
+        fi
+
+        # -----------------------------------------------------------------------------
+        # Add symlink to last backup
+        # -----------------------------------------------------------------------------
+        if [ "$EXIT_CODE" = 0 ]; then
+                # Create the latest symlink only when rsync succeeded
+                fn_rm_file "$DEST_FOLDER/latest"
+                fn_ln "$(basename -- "$DEST")" "$DEST_FOLDER/latest"
+
+                # Remove .inprogress file only when rsync succeeded
+                fn_rm_file "$INPROGRESS_FILE"
+        fi
+
+        exit $EXIT_CODE
 done

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -70,6 +70,7 @@ fn_display_usage() {
         echo "                        not be managed by the script - in particular they will not be"
         echo "                        automatically deleted."
         echo "                        Default: $LOG_DIR"
+        echo " --log-to-destination   Store logs in the destination folder under .$APPNAME/"
         echo " --strategy             Set the expiration strategy. Default: \"1:1 30:7 365:30\" means after one"
         echo "                        day, keep one backup per day. After 30 days, keep one backup every 7 days."
         echo "                        After 365 days keep one backup every 30 days."
@@ -353,6 +354,7 @@ DEST_FOLDER=""
 EXCLUSION_FILE=""
 LOG_DIR="$HOME/.$APPNAME"
 AUTO_DELETE_LOG="1"
+LOG_TO_DEST="0"
 EXPIRATION_STRATEGY="1:1 30:7 365:30"
 AUTO_EXPIRE="1"
 ## --perms --owner --group remove form flags
@@ -399,6 +401,10 @@ while :; do
                 --log-dir)
                         shift
                         LOG_DIR="$1"
+                        AUTO_DELETE_LOG="0"
+                        ;;
+                --log-to-destination)
+                        LOG_TO_DEST="1"
                         AUTO_DELETE_LOG="0"
                         ;;
                 --no-auto-expire)
@@ -524,6 +530,10 @@ MYPID="$$"
 # -----------------------------------------------------------------------------
 # Create log folder if it doesn't exist
 # -----------------------------------------------------------------------------
+
+if [[ $LOG_TO_DEST == "1" ]]; then
+        LOG_DIR="$DEST_FOLDER/.$APPNAME"
+fi
 
 if [ ! -d "$LOG_DIR" ]; then
         fn_log_info "Creating log folder in '$LOG_DIR'..."

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -77,7 +77,7 @@ fn_display_usage() {
         echo "                        is logged, and the backup is aborted."
         echo " -m, --max_backups N    Specify the maximum number of backups (default: 10)."
         echo "                        After this number of backups, script prune backups."
-        echo " --sudo                 script has not run sudo"
+        echo " --no-sudo              script has not run sudo"
         echo ""
         echo "For more detailed help, please see the README file:"
         echo ""
@@ -404,7 +404,6 @@ while :; do
                         AUTO_EXPIRE="0"
                         ;;
                 --sudo)
-                      shift
                       SUDO=true
                       ;;
                 --)

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -77,7 +77,7 @@ fn_display_usage() {
         echo "                        is logged, and the backup is aborted."
         echo " -m, --max_backups N    Specify the maximum number of backups (default: 10)."
         echo "                        After this number of backups, script prune backups."
-        echo " --no-sudo              script has not run sudo"
+        echo " --sudo              script has not run sudo"
         echo ""
         echo "For more detailed help, please see the README file:"
         echo ""

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -296,6 +296,27 @@ fn_df_t() {
         fn_run_cmd "df -T '${1}'"
 }
 
+# Function to set permissions on the last used directory
+fn_fix_permissions() {
+    local base_dir="$1"
+
+    fn_log_info "Fixing permissions in directory: $base_dir"
+
+    # Buscar y cambiar permisos de directorios con 000 a 700
+    find "$base_dir" -type d -perm 000 -exec chmod 700 {} \; || {
+        fn_log_error "Failed to set permissions on some directories"
+        exit 1
+    }
+
+    # Buscar y cambiar permisos de archivos con 000 a 600
+    find "$base_dir" -type f -perm 000 -exec chmod 600 {} \; || {
+        fn_log_error "Failed to set permissions on some files"
+        exit 1
+    }
+
+    fn_log_info "Permissions fixed successfully"
+}
+
 # -----------------------------------------------------------------------------
 # Source and destination information
 # -----------------------------------------------------------------------------
@@ -679,6 +700,10 @@ while : ; do
 
                 # Remove .inprogress file only when rsync succeeded
                 fn_rm_file "$INPROGRESS_FILE"
+
+                ultimo_directorio="$DEST_FOLDER/$(basename -- "$DEST")"
+                fn_log_info "Check permissions on $ultimo_directorio"
+                fn_fix_permissions "$ultimo_directorio"
         fi
 
         exit $EXIT_CODE

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -67,7 +67,7 @@ fn_display_usage() {
         echo " --no-auto-expire       Disable automatically deleting backups when out of space. Instead an error"
         echo "                        is logged, and the backup is aborted."
         echo " -m, --max_backups N    Specify the maximum number of backups (default: 10)."
-        echo "                        After this script prune backups."
+        echo "                        After this number of backups, script prune backups."
         echo ""
         echo "For more detailed help, please see the README file:"
         echo ""
@@ -317,7 +317,7 @@ while :; do
                         ;;
                 -m|--max_backups)
                         shift
-                        MAX_BACKUPS="$1"
+                        MAX_BACKUPS=$1
                         ;;
                 --rsync-get-flags)
                         shift

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -302,14 +302,18 @@ fn_fix_permissions() {
 
     fn_log_info "Fixing permissions in directory: $base_dir"
 
+    find "$base_dir" -type d -perm 0111 -exec sudo chmod 700 {} \; || {
+        fn_log_error "Failed to set permissions on some directories"
+        exit 1
+    }
     # Buscar y cambiar permisos de directorios con 000 a 700
-    find "$base_dir" -type d -perm 000 -exec chmod 700 {} \; || {
+    find "$base_dir" -type d -perm 000 -exec sudo chmod 700 {} \; || {
         fn_log_error "Failed to set permissions on some directories"
         exit 1
     }
 
     # Buscar y cambiar permisos de archivos con 000 a 600
-    find "$base_dir" -type f -perm 000 -exec chmod 600 {} \; || {
+    find "$base_dir" -type f -perm 000 -exec sudo chmod 600 {} \; || {
         fn_log_error "Failed to set permissions on some files"
         exit 1
     }

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -302,18 +302,18 @@ fn_fix_permissions() {
 
     fn_log_info "Fixing permissions in directory: $base_dir"
 
-    find "$base_dir" -type d -perm 0111 -exec sudo chmod 700 {} \; || {
+    find "$base_dir" -type d -perm 0111 -exec chmod 700 {} \; || {
         fn_log_error "Failed to set permissions on some directories"
         exit 1
     }
     # Buscar y cambiar permisos de directorios con 000 a 700
-    find "$base_dir" -type d -perm 000 -exec sudo chmod 700 {} \; || {
+    find "$base_dir" -type d -perm 000 -exec chmod 700 {} \; || {
         fn_log_error "Failed to set permissions on some directories"
         exit 1
     }
 
     # Buscar y cambiar permisos de archivos con 000 a 600
-    find "$base_dir" -type f -perm 000 -exec sudo chmod 600 {} \; || {
+    find "$base_dir" -type f -perm 000 -exec chmod 600 {} \; || {
         fn_log_error "Failed to set permissions on some files"
         exit 1
     }

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -77,6 +77,7 @@ fn_display_usage() {
         echo "                        is logged, and the backup is aborted."
         echo " -m, --max_backups N    Specify the maximum number of backups (default: 10)."
         echo "                        After this number of backups, script prune backups."
+        echo " --no-sudo              script has not run sudo"
         echo ""
         echo "For more detailed help, please see the README file:"
         echo ""
@@ -302,21 +303,33 @@ fn_fix_permissions() {
 
     fn_log_info "Fixing permissions in directory: $base_dir"
 
-    find "$base_dir" -type d -perm 0111 -exec chmod 700 {} \; || {
-        fn_log_error "Failed to set permissions on some directories"
-        exit 1
-    }
-    # Buscar y cambiar permisos de directorios con 000 a 700
-    find "$base_dir" -type d -perm 000 -exec chmod 700 {} \; || {
-        fn_log_error "Failed to set permissions on some directories"
-        exit 1
-    }
-
-    # Buscar y cambiar permisos de archivos con 000 a 600
-    find "$base_dir" -type f -perm 000 -exec chmod 600 {} \; || {
-        fn_log_error "Failed to set permissions on some files"
-        exit 1
-    }
+    if [ "$SUDO" = true ]; then
+            find "$base_dir" -type d -perm 0111 -exec sudo chmod 700 {} \; || {
+                fn_log_error "Failed to set permissions on some directories"
+                exit 1
+            }
+            find "$base_dir" -type d -perm 000 -exec sudo chmod 700 {} \; || {
+                fn_log_error "Failed to set permissions on some directories"
+                exit 1
+            }
+            find "$base_dir" -type f -perm 000 -exec sudo chmod 600 {} \; || {
+                fn_log_error "Failed to set permissions on some files"
+                exit 1
+            }
+        else
+            find "$base_dir" -type d -perm 0111 -exec chmod 700 {} \; || {
+                fn_log_error "Failed to set permissions on some directories"
+                exit 1
+            }
+            find "$base_dir" -type d -perm 000 -exec chmod 700 {} \; || {
+                fn_log_error "Failed to set permissions on some directories"
+                exit 1
+            }
+            find "$base_dir" -type f -perm 000 -exec chmod 600 {} \; || {
+                fn_log_error "Failed to set permissions on some files"
+                exit 1
+            }
+        fi
 
     fn_log_info "Permissions fixed successfully"
 }
@@ -345,6 +358,7 @@ AUTO_EXPIRE="1"
 RSYNC_FLAGS="-D --numeric-ids --links --hard-links --one-file-system --itemize-changes --times --recursive --stats --human-readable"
 
 MAX_BACKUPS="10"
+SUDO=false
 
 while :; do
         case $1 in
@@ -389,6 +403,10 @@ while :; do
                 --no-auto-expire)
                         AUTO_EXPIRE="0"
                         ;;
+                --no-sudo)
+                      shift
+                      SUDO=true
+                      ;;
                 --)
                         shift
                         SRC_FOLDER="$1"

--- a/rsync_tmbackup.sh
+++ b/rsync_tmbackup.sh
@@ -77,7 +77,7 @@ fn_display_usage() {
         echo "                        is logged, and the backup is aborted."
         echo " -m, --max_backups N    Specify the maximum number of backups (default: 10)."
         echo "                        After this number of backups, script prune backups."
-        echo " --no-sudo              script has not run sudo"
+        echo " --sudo                 script has not run sudo"
         echo ""
         echo "For more detailed help, please see the README file:"
         echo ""
@@ -403,7 +403,7 @@ while :; do
                 --no-auto-expire)
                         AUTO_EXPIRE="0"
                         ;;
-                --no-sudo)
+                --sudo)
                       shift
                       SUDO=true
                       ;;

--- a/tests/01_basic.bats
+++ b/tests/01_basic.bats
@@ -1,0 +1,149 @@
+#!/usr/bin/env bats
+#
+# Basic tests for rsync_tmbackup.sh
+# These tests verify fundamental functionality without running actual backups
+#
+
+load 'test_helper'
+
+# =============================================================================
+# Setup and Teardown
+# =============================================================================
+
+setup() {
+    setup_test_environment
+}
+
+teardown() {
+    teardown_test_environment
+}
+
+# =============================================================================
+# Script Existence and Permissions
+# =============================================================================
+
+@test "script exists" {
+    assert_file_exists "$SCRIPT_PATH"
+}
+
+@test "script is executable" {
+    assert_file_executable "$SCRIPT_PATH"
+}
+
+@test "script starts with proper shebang" {
+    run head -1 "$SCRIPT_PATH"
+    assert_output --partial "#!/usr/bin/env bash"
+}
+
+# =============================================================================
+# Help and Usage
+# =============================================================================
+
+@test "displays help with -h flag" {
+    run "$SCRIPT_PATH" -h
+    assert_success
+    assert_output --partial "Usage:"
+    assert_output --partial "Options"
+}
+
+@test "displays help with --help flag" {
+    run "$SCRIPT_PATH" --help
+    assert_success
+    assert_output --partial "Usage:"
+}
+
+@test "shows max_backups option in help" {
+    run "$SCRIPT_PATH" --help
+    assert_success
+    assert_output --partial "--max_backups"
+}
+
+@test "shows sudo option in help" {
+    run "$SCRIPT_PATH" --help
+    assert_success
+    assert_output --partial "--sudo"
+}
+
+@test "shows log-to-destination option in help" {
+    run "$SCRIPT_PATH" --help
+    assert_success
+    assert_output --partial "--log-to-destination"
+}
+
+# =============================================================================
+# Rsync Flags
+# =============================================================================
+
+@test "displays rsync flags with --rsync-get-flags" {
+    run "$SCRIPT_PATH" --rsync-get-flags
+    assert_success
+    assert_output --partial "--recursive"
+    assert_output --partial "--hard-links"
+}
+
+@test "rsync flags do not include --perms by default" {
+    # This is a fork-specific change for non-root environments
+    run "$SCRIPT_PATH" --rsync-get-flags
+    assert_success
+    refute_output --partial "--perms"
+}
+
+@test "rsync flags do not include --owner by default" {
+    run "$SCRIPT_PATH" --rsync-get-flags
+    assert_success
+    refute_output --partial "--owner"
+}
+
+@test "rsync flags do not include --group by default" {
+    run "$SCRIPT_PATH" --rsync-get-flags
+    assert_success
+    refute_output --partial "--group"
+}
+
+# =============================================================================
+# Input Validation
+# =============================================================================
+
+@test "fails without arguments" {
+    run "$SCRIPT_PATH"
+    assert_failure
+    assert_output --partial "Usage:"
+}
+
+@test "fails with only source argument" {
+    run "$SCRIPT_PATH" "$TEST_SOURCE"
+    assert_failure
+    assert_output --partial "Usage:"
+}
+
+@test "fails when source folder does not exist" {
+    run "$SCRIPT_PATH" "/nonexistent/source/path" "$TEST_DEST"
+    assert_failure
+    assert_output --partial "does not exist"
+}
+
+@test "fails when destination has no backup.marker" {
+    rm "$TEST_DEST/backup.marker"
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+    assert_failure
+    assert_output --partial "marker"
+}
+
+@test "rejects source path with single quotes" {
+    # The script checks for single quotes in paths and rejects them
+    # However, if the path doesn't exist, it fails with "does not exist" first
+    # So we test with a valid path that has quotes
+    mkdir -p "$TEST_TEMP_DIR/path'with'quotes"
+    touch "$TEST_TEMP_DIR/path'with'quotes/file.txt"
+
+    run "$SCRIPT_PATH" "$TEST_TEMP_DIR/path'with'quotes" "$TEST_DEST"
+    assert_failure
+    # Either fails with "single quote" error or "does not exist"
+    # depending on order of checks in script
+}
+
+@test "rejects unknown option" {
+    run "$SCRIPT_PATH" --unknown-option "$TEST_SOURCE" "$TEST_DEST"
+    assert_failure
+    assert_output --partial "Unknown option"
+}

--- a/tests/02_backup.bats
+++ b/tests/02_backup.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+#
+# Backup functionality tests for rsync_tmbackup.sh
+# These tests verify actual backup operations
+#
+
+load 'test_helper'
+
+# =============================================================================
+# Setup and Teardown
+# =============================================================================
+
+setup() {
+    setup_test_environment
+    create_sample_structure "$TEST_SOURCE"
+}
+
+teardown() {
+    teardown_test_environment
+}
+
+# =============================================================================
+# Basic Backup Operations
+# =============================================================================
+
+@test "creates backup directory with timestamp format" {
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    # Check that a backup directory was created with the right format
+    local backup_dirs
+    backup_dirs=$(find "$TEST_DEST" -maxdepth 1 -type d -name "????-??-??-??????" | wc -l)
+    [ "$backup_dirs" -gt 0 ]
+}
+
+@test "backup contains source files" {
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    # Find the backup directory
+    local backup_dir
+    backup_dir=$(find "$TEST_DEST" -maxdepth 1 -type d -name "????-??-??-??????" | head -1)
+
+    assert_file_exists "$backup_dir/root.txt"
+    assert_file_exists "$backup_dir/subdir1/sub1.txt"
+    assert_file_exists "$backup_dir/subdir1/nested/nested.txt"
+    assert_file_exists "$backup_dir/subdir2/sub2.txt"
+}
+
+@test "creates 'latest' symlink after successful backup" {
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    assert_link_exists "$TEST_DEST/latest"
+}
+
+@test "latest symlink points to most recent backup" {
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    local backup_dir
+    backup_dir=$(find "$TEST_DEST" -maxdepth 1 -type d -name "????-??-??-??????" | head -1)
+    local backup_name
+    backup_name=$(basename "$backup_dir")
+
+    local link_target
+    link_target=$(readlink "$TEST_DEST/latest")
+
+    [ "$link_target" = "$backup_name" ]
+}
+
+@test "removes inprogress file after successful backup" {
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    assert_file_not_exists "$TEST_DEST/backup.inprogress"
+}
+
+# =============================================================================
+# Incremental Backups
+# =============================================================================
+
+@test "second backup uses hard links for unchanged files" {
+    # First backup
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    # Wait a second to ensure different timestamp
+    sleep 1
+
+    # Second backup without changes
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    # Should have 2 backup directories
+    local backup_count
+    backup_count=$(count_backups "$TEST_DEST")
+    [ "$backup_count" -eq 2 ]
+
+    # Get both backup directories
+    local backups
+    backups=$(find "$TEST_DEST" -maxdepth 1 -type d -name "????-??-??-??????" | sort)
+    local first_backup second_backup
+    first_backup=$(echo "$backups" | head -1)
+    second_backup=$(echo "$backups" | tail -1)
+
+    # Check that files are hard-linked (same inode)
+    local inode1 inode2
+    inode1=$(stat -f %i "$first_backup/root.txt" 2>/dev/null || stat -c %i "$first_backup/root.txt")
+    inode2=$(stat -f %i "$second_backup/root.txt" 2>/dev/null || stat -c %i "$second_backup/root.txt")
+
+    [ "$inode1" = "$inode2" ]
+}
+
+@test "modified files get new copy in incremental backup" {
+    # First backup
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    # Modify a file
+    echo "modified content" > "$TEST_SOURCE/root.txt"
+    sleep 1
+
+    # Second backup
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    # Get both backup directories
+    local backups
+    backups=$(find "$TEST_DEST" -maxdepth 1 -type d -name "????-??-??-??????" | sort)
+    local first_backup second_backup
+    first_backup=$(echo "$backups" | head -1)
+    second_backup=$(echo "$backups" | tail -1)
+
+    # Verify content is different
+    local content1 content2
+    content1=$(cat "$first_backup/root.txt")
+    content2=$(cat "$second_backup/root.txt")
+
+    [ "$content1" != "$content2" ]
+    [ "$content2" = "modified content" ]
+}
+
+# =============================================================================
+# Log Files
+# =============================================================================
+
+@test "creates log file during backup" {
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+    # Note: log file is deleted on success by default, so we check for directory
+    assert_success
+}
+
+@test "log-to-destination creates logs in dest folder" {
+    run "$SCRIPT_PATH" --log-to-destination "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    # Log directory should exist in destination
+    assert_dir_exists "$TEST_DEST/.rsync_tmbackup"
+}

--- a/tests/03_options.bats
+++ b/tests/03_options.bats
@@ -1,0 +1,202 @@
+#!/usr/bin/env bats
+#
+# CLI options tests for rsync_tmbackup.sh
+# Tests for command-line argument parsing and option behavior
+#
+
+load 'test_helper'
+
+# =============================================================================
+# Setup and Teardown
+# =============================================================================
+
+setup() {
+    setup_test_environment
+    create_sample_files "$TEST_SOURCE" 3
+}
+
+teardown() {
+    teardown_test_environment
+}
+
+# =============================================================================
+# Max Backups Option (-m / --max_backups)
+# =============================================================================
+
+@test "max_backups option accepts -m flag" {
+    run "$SCRIPT_PATH" -m 5 "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+}
+
+@test "max_backups option accepts --max_backups flag" {
+    run "$SCRIPT_PATH" --max_backups 5 "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+}
+
+@test "max_backups limits number of kept backups" {
+    # Create initial backup
+    run "$SCRIPT_PATH" -m 3 "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    # Create more backups than the limit
+    for i in 1 2 3 4; do
+        sleep 1
+        echo "iteration $i" >> "$TEST_SOURCE/file_1.txt"
+        run "$SCRIPT_PATH" -m 3 "$TEST_SOURCE" "$TEST_DEST"
+        assert_success
+    done
+
+    # Should have at most 3 backups
+    local count
+    count=$(count_backups "$TEST_DEST")
+    [ "$count" -le 3 ]
+}
+
+@test "max_backups prunes oldest backups first" {
+    # Create 2 backups
+    run "$SCRIPT_PATH" -m 2 "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+    sleep 1
+
+    echo "second backup" >> "$TEST_SOURCE/file_1.txt"
+    run "$SCRIPT_PATH" -m 2 "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+    sleep 1
+
+    # Get first two backup names
+    local first_backup second_backup
+    first_backup=$(find "$TEST_DEST" -maxdepth 1 -type d -name "????-??-??-??????" | sort | head -1 | xargs basename)
+    second_backup=$(find "$TEST_DEST" -maxdepth 1 -type d -name "????-??-??-??????" | sort | tail -1 | xargs basename)
+
+    # Create third backup with limit of 2
+    echo "third backup" >> "$TEST_SOURCE/file_1.txt"
+    run "$SCRIPT_PATH" -m 2 "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    # First backup should be gone
+    assert_dir_not_exists "$TEST_DEST/$first_backup"
+
+    # Second backup should still exist
+    assert_dir_exists "$TEST_DEST/$second_backup"
+}
+
+# =============================================================================
+# Rsync Flags Options
+# =============================================================================
+
+@test "rsync-append-flags adds custom flags" {
+    run "$SCRIPT_PATH" --rsync-append-flags "--dry-run" "$TEST_SOURCE" "$TEST_DEST"
+    # With --dry-run, no actual backup should be created
+    assert_success
+}
+
+@test "rsync-set-flags replaces default flags" {
+    run "$SCRIPT_PATH" --rsync-set-flags "-av" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+}
+
+# =============================================================================
+# Expiration Strategy Option
+# =============================================================================
+
+@test "strategy option accepts custom strategy" {
+    run "$SCRIPT_PATH" --strategy "1:1 7:2 30:7" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+}
+
+# =============================================================================
+# Log Directory Options
+# =============================================================================
+
+@test "log-dir option sets custom log directory" {
+    local custom_log_dir="$TEST_TEMP_DIR/custom_logs"
+    mkdir -p "$custom_log_dir"
+
+    run "$SCRIPT_PATH" --log-dir "$custom_log_dir" "$TEST_SOURCE" "$TEST_DEST"
+    # Note: logs are auto-deleted on success, but directory should be used
+    assert_success
+}
+
+@test "log-to-destination stores logs in destination" {
+    run "$SCRIPT_PATH" --log-to-destination "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    # Check for log directory in destination
+    assert_dir_exists "$TEST_DEST/.rsync_tmbackup"
+}
+
+# =============================================================================
+# No Auto Expire Option
+# =============================================================================
+
+@test "no-auto-expire option is accepted" {
+    run "$SCRIPT_PATH" --no-auto-expire "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+}
+
+# =============================================================================
+# Sudo Option
+# =============================================================================
+
+@test "sudo option is accepted" {
+    run "$SCRIPT_PATH" --sudo "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+}
+
+# =============================================================================
+# SSH Options
+# =============================================================================
+
+@test "port option accepts -p flag" {
+    # This won't actually connect, but should parse the option
+    run "$SCRIPT_PATH" -p 2222 --help
+    assert_success
+}
+
+@test "id_rsa option accepts -i flag" {
+    run "$SCRIPT_PATH" -i /path/to/key --help
+    assert_success
+}
+
+# =============================================================================
+# Exclusion File
+# =============================================================================
+
+@test "exclusion file is used when provided" {
+    local exclude_file="$TEST_TEMP_DIR/excludes.txt"
+    echo "file_1.txt" > "$exclude_file"
+
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST" "$exclude_file"
+    assert_success
+
+    # Find the backup directory
+    local backup_dir
+    backup_dir=$(find "$TEST_DEST" -maxdepth 1 -type d -name "????-??-??-??????" | head -1)
+
+    # Excluded file should not exist
+    assert_file_not_exists "$backup_dir/file_1.txt"
+
+    # Other files should exist
+    assert_file_exists "$backup_dir/file_2.txt"
+}
+
+@test "exclusion file with filter rules uses --filter" {
+    local exclude_file="$TEST_TEMP_DIR/filters.txt"
+    cat > "$exclude_file" << 'EOF'
+- file_1.txt
++ file_2.txt
+- *.txt
+EOF
+
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST" "$exclude_file"
+    assert_success
+
+    local backup_dir
+    backup_dir=$(find "$TEST_DEST" -maxdepth 1 -type d -name "????-??-??-??????" | head -1)
+
+    # file_1.txt excluded
+    assert_file_not_exists "$backup_dir/file_1.txt"
+
+    # file_2.txt explicitly included
+    assert_file_exists "$backup_dir/file_2.txt"
+}

--- a/tests/04_expiration.bats
+++ b/tests/04_expiration.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+#
+# Backup expiration and pruning tests for rsync_tmbackup.sh
+# Tests for the expiration strategy and max_backups pruning
+#
+
+load 'test_helper'
+
+# =============================================================================
+# Setup and Teardown
+# =============================================================================
+
+setup() {
+    setup_test_environment
+    create_sample_files "$TEST_SOURCE" 2
+}
+
+teardown() {
+    teardown_test_environment
+}
+
+# =============================================================================
+# Pruning by Count (max_backups)
+# =============================================================================
+
+@test "prune keeps exactly max_backups when exceeded" {
+    # Create 5 backups with max_backups=3
+    for i in 1 2 3 4 5; do
+        sleep 1
+        echo "backup $i" >> "$TEST_SOURCE/file_1.txt"
+        run "$SCRIPT_PATH" -m 3 "$TEST_SOURCE" "$TEST_DEST"
+        assert_success
+    done
+
+    local count
+    count=$(count_backups "$TEST_DEST")
+    [ "$count" -le 3 ]
+}
+
+@test "prune removes oldest backup when limit reached" {
+    # Create first backup
+    run "$SCRIPT_PATH" -m 2 "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+    local oldest
+    oldest=$(find "$TEST_DEST" -maxdepth 1 -type d -name "????-??-??-??????" | head -1)
+    local oldest_name
+    oldest_name=$(basename "$oldest")
+
+    sleep 1
+
+    # Second backup
+    echo "second" >> "$TEST_SOURCE/file_1.txt"
+    run "$SCRIPT_PATH" -m 2 "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    sleep 1
+
+    # Third backup (should trigger pruning of oldest)
+    echo "third" >> "$TEST_SOURCE/file_1.txt"
+    run "$SCRIPT_PATH" -m 2 "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    # Oldest should be pruned
+    assert_dir_not_exists "$TEST_DEST/$oldest_name"
+
+    # Should have exactly 2 backups
+    local count
+    count=$(count_backups "$TEST_DEST")
+    [ "$count" -eq 2 ]
+}
+
+# =============================================================================
+# Default Expiration Strategy
+# =============================================================================
+
+@test "default strategy is 1:1 30:7 365:30" {
+    # This test verifies the default strategy is applied
+    # We can't easily test complex expiration without time manipulation
+    # but we can verify the script accepts the default
+
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+}
+
+@test "custom strategy is accepted and applied" {
+    # Simple strategy: keep one per day
+    run "$SCRIPT_PATH" --strategy "1:1" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+}
+
+# =============================================================================
+# Edge Cases
+# =============================================================================
+
+@test "single backup is never pruned" {
+    run "$SCRIPT_PATH" -m 1 "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    local count
+    count=$(count_backups "$TEST_DEST")
+    [ "$count" -eq 1 ]
+}
+
+@test "backup with malformed date directory is skipped during expiration" {
+    # Create a normal backup first
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    # Create a malformed directory that looks like a backup but isn't valid
+    mkdir -p "$TEST_DEST/not-a-valid-date"
+
+    sleep 1
+
+    # Create another backup - should not crash
+    echo "second backup" >> "$TEST_SOURCE/file_1.txt"
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    # Malformed directory should still exist (not deleted by expiration)
+    assert_dir_exists "$TEST_DEST/not-a-valid-date"
+}
+
+# =============================================================================
+# Safety Checks
+# =============================================================================
+
+@test "expiration only works on directories with backup.marker" {
+    # This is a critical safety feature
+    # The script should verify backup.marker exists before expiring
+
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    # Backup should be in a directory with backup.marker
+    local backup_dir
+    backup_dir=$(find "$TEST_DEST" -maxdepth 1 -type d -name "????-??-??-??????" | head -1)
+    local parent_dir
+    parent_dir=$(dirname "$backup_dir")
+
+    assert_file_exists "$parent_dir/backup.marker"
+}

--- a/tests/05_resume.bats
+++ b/tests/05_resume.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+#
+# Backup resume and recovery tests for rsync_tmbackup.sh
+# Tests for handling interrupted backups and recovery
+#
+
+load 'test_helper'
+
+# =============================================================================
+# Setup and Teardown
+# =============================================================================
+
+setup() {
+    setup_test_environment
+    create_sample_structure "$TEST_SOURCE"
+}
+
+teardown() {
+    teardown_test_environment
+}
+
+# =============================================================================
+# Inprogress File Handling
+# =============================================================================
+
+@test "creates inprogress file during backup" {
+    # We can't easily test this mid-backup, but we can verify
+    # it's removed after a successful backup
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    # Inprogress should be removed after success
+    assert_file_not_exists "$TEST_DEST/backup.inprogress"
+}
+
+@test "detects and handles stale inprogress file" {
+    # Simulate an interrupted backup
+    echo "99999" > "$TEST_DEST/backup.inprogress"
+
+    # Create a partial backup directory
+    mkdir -p "$TEST_DEST/2024-01-01-120000"
+    echo "partial" > "$TEST_DEST/2024-01-01-120000/partial.txt"
+
+    # Running backup should detect and resume
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    # Should see resume message in output
+    assert_output --partial "resume"
+}
+
+@test "does not resume if previous process is still running" {
+    # Get our own PID (simulating a running backup)
+    echo "$$" > "$TEST_DEST/backup.inprogress"
+
+    # This might fail or detect running process depending on timing
+    # The important thing is it doesn't corrupt anything
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+
+    # Either succeeds (different process) or fails safely
+    # We mainly verify it doesn't crash unexpectedly
+    true
+}
+
+# =============================================================================
+# Recovery from Partial Backups
+# =============================================================================
+
+@test "resumes from partial backup with missing files" {
+    # Create a partial backup situation
+    echo "12345" > "$TEST_DEST/backup.inprogress"
+    mkdir -p "$TEST_DEST/2024-01-01-120000/subdir1"
+    echo "existing file" > "$TEST_DEST/2024-01-01-120000/subdir1/sub1.txt"
+
+    # Run backup - should resume and complete
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    # All files should now exist in a backup
+    local backup_dir
+    backup_dir=$(find "$TEST_DEST" -maxdepth 1 -type d -name "????-??-??-??????" | head -1)
+
+    assert_file_exists "$backup_dir/root.txt"
+    assert_file_exists "$backup_dir/subdir1/sub1.txt"
+}
+
+# =============================================================================
+# Lock Mechanism
+# =============================================================================
+
+@test "prevents concurrent backups to same destination" {
+    # This is tricky to test without actual concurrency
+    # We verify the mechanism exists by checking inprogress handling
+
+    # First backup
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+
+    # Inprogress should be gone
+    assert_file_not_exists "$TEST_DEST/backup.inprogress"
+
+    # Second backup should also work (no lock contention)
+    sleep 1
+    echo "modified" >> "$TEST_SOURCE/root.txt"
+    run "$SCRIPT_PATH" "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,162 @@
+# Testing rsync_tmbackup.sh
+
+This directory contains automated tests for `rsync_tmbackup.sh` using the [bats-core](https://github.com/bats-core/bats-core) testing framework.
+
+## Quick Start
+
+```bash
+# Install bats (first time only)
+./tests/setup_bats.sh
+
+# Run all tests
+./tests/run_tests.sh
+
+# Run specific test file
+./tests/run_tests.sh 01_basic
+
+# Run with verbose output
+./tests/run_tests.sh --verbose
+```
+
+## Test Files
+
+| File | Description | Tests |
+|------|-------------|-------|
+| `01_basic.bats` | Script existence, help, flags, input validation | 18 |
+| `02_backup.bats` | Backup creation, incremental backups, symlinks | 9 |
+| `03_options.bats` | CLI options: max_backups, rsync flags, exclusions | 15 |
+| `04_expiration.bats` | Backup expiration and pruning logic | 7 |
+| `05_resume.bats` | Interrupted backup handling and recovery | 5 |
+
+**Total: 54 tests**
+
+## What is Bats?
+
+Bats (Bash Automated Testing System) is a TAP-compliant testing framework for Bash. Each test is a function that runs in isolation:
+
+```bash
+@test "displays help with -h flag" {
+    run ./rsync_tmbackup.sh -h
+    assert_success
+    assert_output --partial "Usage:"
+}
+```
+
+Key concepts:
+
+- `@test "description"` - Defines a test case
+- `run` - Executes a command and captures output/status
+- `assert_success` - Verifies exit code is 0
+- `assert_failure` - Verifies exit code is non-zero
+- `assert_output --partial "text"` - Checks output contains text
+- `assert_file_exists` - Verifies file exists
+
+## Test Structure
+
+```
+tests/
+├── setup_bats.sh       # Installs bats-core and helpers
+├── run_tests.sh        # Test runner script
+├── test_helper.bash    # Common functions for all tests
+├── 01_basic.bats       # Basic functionality tests
+├── 02_backup.bats      # Backup operation tests
+├── 03_options.bats     # CLI options tests
+├── 04_expiration.bats  # Expiration/pruning tests
+├── 05_resume.bats      # Resume/recovery tests
+├── bats/               # (gitignored) bats-core installation
+│   ├── bats-core/
+│   ├── bats-assert/
+│   ├── bats-support/
+│   └── bats-file/
+└── README.md           # This file
+```
+
+## Writing New Tests
+
+1. Create a new `.bats` file or add to existing one
+2. Load the test helper at the top:
+
+```bash
+#!/usr/bin/env bats
+load 'test_helper'
+```
+
+3. Use setup/teardown for test isolation:
+
+```bash
+setup() {
+    setup_test_environment
+}
+
+teardown() {
+    teardown_test_environment
+}
+```
+
+4. Write tests using the `@test` syntax:
+
+```bash
+@test "my new test" {
+    run "$SCRIPT_PATH" --my-option "$TEST_SOURCE" "$TEST_DEST"
+    assert_success
+}
+```
+
+## Helper Functions
+
+The `test_helper.bash` provides:
+
+| Function | Description |
+|----------|-------------|
+| `setup_test_environment` | Creates temp source/dest with backup.marker |
+| `teardown_test_environment` | Cleans up temp directories |
+| `create_sample_files` | Creates N sample files in a directory |
+| `create_sample_structure` | Creates a nested directory structure |
+| `create_fake_backups` | Creates fake backup directories for testing |
+| `count_backups` | Counts backup directories in destination |
+| `run_backup` | Runs the backup script |
+
+## CI Integration
+
+To run tests in CI (GitHub Actions, GitLab CI, etc.):
+
+```yaml
+# GitHub Actions example
+test:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - name: Setup bats
+      run: ./tests/setup_bats.sh
+    - name: Run tests
+      run: ./tests/run_tests.sh
+```
+
+## Troubleshooting
+
+### Tests fail with "bats not found"
+
+Run `./tests/setup_bats.sh` to install bats-core locally.
+
+### Tests are slow
+
+Some tests create actual backups. Use `--verbose` to see which tests are running:
+
+```bash
+./tests/run_tests.sh --verbose
+```
+
+### Test cleanup issues
+
+If temp directories aren't cleaned up, check the `teardown` function is being called. You can manually clean with:
+
+```bash
+rm -rf /tmp/tmp.*  # Be careful with this!
+```
+
+## Resources
+
+- [bats-core documentation](https://bats-core.readthedocs.io/)
+- [bats-assert](https://github.com/bats-core/bats-assert) - Assertion library
+- [bats-file](https://github.com/bats-core/bats-file) - File assertions
+- [Writing tests guide](https://bats-core.readthedocs.io/en/stable/writing-tests.html)

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Run all bats tests for rsync_tmbackup.sh
+#
+# Usage:
+#   ./tests/run_tests.sh              # Run all tests
+#   ./tests/run_tests.sh 01_basic     # Run specific test file
+#   ./tests/run_tests.sh --verbose    # Run with verbose output
+#
+
+set -e
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BATS_DIR="$TESTS_DIR/bats"
+BATS_BIN="$BATS_DIR/bats-core/bin/bats"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Check if bats is installed
+if [ ! -x "$BATS_BIN" ]; then
+    echo -e "${YELLOW}Bats not found. Installing...${NC}"
+    "$TESTS_DIR/setup_bats.sh"
+    echo ""
+fi
+
+# Parse arguments
+VERBOSE=""
+TEST_FILES=()
+
+for arg in "$@"; do
+    case $arg in
+        --verbose|-v)
+            VERBOSE="--verbose-run"
+            ;;
+        --tap)
+            VERBOSE="--tap"
+            ;;
+        --help|-h)
+            echo "Usage: $0 [OPTIONS] [TEST_FILES...]"
+            echo ""
+            echo "Options:"
+            echo "  -v, --verbose    Show verbose test output"
+            echo "  --tap            Output in TAP format"
+            echo "  -h, --help       Show this help message"
+            echo ""
+            echo "Examples:"
+            echo "  $0                   Run all tests"
+            echo "  $0 01_basic          Run only 01_basic.bats"
+            echo "  $0 --verbose         Run all tests with verbose output"
+            exit 0
+            ;;
+        *)
+            # Check if it's a test file name
+            if [ -f "$TESTS_DIR/${arg}.bats" ]; then
+                TEST_FILES+=("$TESTS_DIR/${arg}.bats")
+            elif [ -f "$TESTS_DIR/$arg" ]; then
+                TEST_FILES+=("$TESTS_DIR/$arg")
+            elif [ -f "$arg" ]; then
+                TEST_FILES+=("$arg")
+            else
+                echo -e "${RED}Unknown option or test file: $arg${NC}"
+                exit 1
+            fi
+            ;;
+    esac
+done
+
+# If no test files specified, run all
+if [ ${#TEST_FILES[@]} -eq 0 ]; then
+    TEST_FILES=("$TESTS_DIR"/*.bats)
+fi
+
+echo -e "${GREEN}========================================${NC}"
+echo -e "${GREEN}  rsync_tmbackup.sh Test Suite${NC}"
+echo -e "${GREEN}========================================${NC}"
+echo ""
+echo "Running tests: ${TEST_FILES[*]}"
+echo ""
+
+# Run bats
+"$BATS_BIN" $VERBOSE "${TEST_FILES[@]}"
+
+echo ""
+echo -e "${GREEN}All tests completed!${NC}"

--- a/tests/setup_bats.sh
+++ b/tests/setup_bats.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Script to install bats-core and helper libraries for testing rsync_tmbackup.sh
+#
+# Usage: ./tests/setup_bats.sh
+#
+
+set -e
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BATS_DIR="$TESTS_DIR/bats"
+
+echo "Setting up bats-core testing framework..."
+
+# Create bats directory
+mkdir -p "$BATS_DIR"
+
+# Clone bats-core if not exists
+if [ ! -d "$BATS_DIR/bats-core" ]; then
+    echo "Cloning bats-core..."
+    git clone --depth 1 https://github.com/bats-core/bats-core.git "$BATS_DIR/bats-core"
+else
+    echo "bats-core already exists, skipping..."
+fi
+
+# Clone bats-support (helper library)
+if [ ! -d "$BATS_DIR/bats-support" ]; then
+    echo "Cloning bats-support..."
+    git clone --depth 1 https://github.com/bats-core/bats-support.git "$BATS_DIR/bats-support"
+else
+    echo "bats-support already exists, skipping..."
+fi
+
+# Clone bats-assert (assertion library)
+if [ ! -d "$BATS_DIR/bats-assert" ]; then
+    echo "Cloning bats-assert..."
+    git clone --depth 1 https://github.com/bats-core/bats-assert.git "$BATS_DIR/bats-assert"
+else
+    echo "bats-assert already exists, skipping..."
+fi
+
+# Clone bats-file (file assertions)
+if [ ! -d "$BATS_DIR/bats-file" ]; then
+    echo "Cloning bats-file..."
+    git clone --depth 1 https://github.com/bats-core/bats-file.git "$BATS_DIR/bats-file"
+else
+    echo "bats-file already exists, skipping..."
+fi
+
+echo ""
+echo "Setup complete!"
+echo ""
+echo "To run tests:"
+echo "  $BATS_DIR/bats-core/bin/bats $TESTS_DIR/*.bats"
+echo ""
+echo "Or add an alias:"
+echo "  alias bats='$BATS_DIR/bats-core/bin/bats'"

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Common helper functions for bats tests
+#
+
+# Get the directory where this helper is located
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$TESTS_DIR")"
+SCRIPT_PATH="$PROJECT_ROOT/rsync_tmbackup.sh"
+
+# Load bats helper libraries
+load "${TESTS_DIR}/bats/bats-support/load"
+load "${TESTS_DIR}/bats/bats-assert/load"
+load "${TESTS_DIR}/bats/bats-file/load"
+
+# Create a temporary test environment
+setup_test_environment() {
+    # Create unique temp directory for this test
+    TEST_TEMP_DIR="$(mktemp -d)"
+    TEST_SOURCE="$TEST_TEMP_DIR/source"
+    TEST_DEST="$TEST_TEMP_DIR/dest"
+
+    mkdir -p "$TEST_SOURCE"
+    mkdir -p "$TEST_DEST"
+
+    # Create backup.marker (required by the script)
+    touch "$TEST_DEST/backup.marker"
+
+    export TEST_TEMP_DIR TEST_SOURCE TEST_DEST
+}
+
+# Clean up temporary test environment
+teardown_test_environment() {
+    if [ -n "$TEST_TEMP_DIR" ] && [ -d "$TEST_TEMP_DIR" ]; then
+        rm -rf "$TEST_TEMP_DIR"
+    fi
+}
+
+# Create sample files in source directory
+create_sample_files() {
+    local dir="${1:-$TEST_SOURCE}"
+    local count="${2:-5}"
+
+    for i in $(seq 1 "$count"); do
+        echo "Sample content $i - $(date +%s)" > "$dir/file_$i.txt"
+    done
+}
+
+# Create sample directory structure
+create_sample_structure() {
+    local dir="${1:-$TEST_SOURCE}"
+
+    mkdir -p "$dir/subdir1/nested"
+    mkdir -p "$dir/subdir2"
+
+    echo "root file" > "$dir/root.txt"
+    echo "subdir1 file" > "$dir/subdir1/sub1.txt"
+    echo "nested file" > "$dir/subdir1/nested/nested.txt"
+    echo "subdir2 file" > "$dir/subdir2/sub2.txt"
+}
+
+# Create fake backup directories (for testing expiration/pruning)
+create_fake_backups() {
+    local dest="${1:-$TEST_DEST}"
+    local count="${2:-5}"
+    local days_ago="${3:-0}"
+
+    for i in $(seq 1 "$count"); do
+        local offset=$((days_ago + i))
+        local backup_date=$(date -v-"${offset}"d +"%Y-%m-%d-%H%M%S" 2>/dev/null || \
+                           date -d "-${offset} days" +"%Y-%m-%d-%H%M%S")
+        mkdir -p "$dest/$backup_date"
+        echo "backup $i" > "$dest/$backup_date/marker.txt"
+    done
+}
+
+# Count backup directories
+count_backups() {
+    local dest="${1:-$TEST_DEST}"
+    find "$dest" -maxdepth 1 -type d -name "????-??-??-??????" | wc -l | tr -d ' '
+}
+
+# Get the script name for running
+get_script() {
+    echo "$SCRIPT_PATH"
+}
+
+# Run the backup script with common options
+run_backup() {
+    run "$SCRIPT_PATH" "$@"
+}
+
+# Assert backup was created successfully
+assert_backup_created() {
+    local dest="${1:-$TEST_DEST}"
+    local count
+    count=$(count_backups "$dest")
+    [ "$count" -gt 0 ] || fail "Expected at least one backup, found $count"
+}
+
+# Assert specific number of backups exist
+assert_backup_count() {
+    local expected="$1"
+    local dest="${2:-$TEST_DEST}"
+    local actual
+    actual=$(count_backups "$dest")
+    [ "$actual" -eq "$expected" ] || fail "Expected $expected backups, found $actual"
+}


### PR DESCRIPTION
## Summary

`fn_expire_backup` invocaba `fn_rm_dir` directamente sin sanear permisos. Cuando un snapshot envejece y contiene ficheros/dirs sin `u+w` (típico de ISPConfig `.php-fcgi-starter` 0500, `web1/` 0550, o `/etc/ssl/private/` 0700), `rm -rf` falla con `Permission denied` y aborta todo el backup.

Caso real detectado en stor01-ovh (user kvm476):

\`\`\`
rm: cannot remove '.../2026-01-19-124749/var/www/php-fcgi-scripts/web1/.php-fcgi-starter': Permission denied
\`\`\`

## Changes

1. **`fn_fix_permissions`** — filtro ampliado de `-perm 0111`/`-perm 000` a `! -perm -u=w`. Captura cualquier dir/file donde el propietario carece de write (0400, 0500, 0550, 0700, 0710...). Ramas SUDO colapsadas en un único `\$sudo_cmd`.
2. **`fn_expire_backup`** — llama a `fn_fix_permissions` sobre el snapshot antes de `fn_rm_dir`, condicionado a destino local (la función no usa `fn_run_cmd`, no es SSH-aware).

## Test plan

- [x] Tests bats nuevos en `tests/06_expire_perms.bats`:
  - Escenario `.php-fcgi-starter` 0500 dentro de `web1/` 0550
  - Clave privada 0400 dentro de `/etc/ssl/private/` 0700
- [x] Suite completa: 56/56 OK
- [ ] CI green en GitHub Actions

## Storages afectados (propagación tras merge)

- `stor01-ovh` (user kvm476) — origen del bug
- `localstor-indiva` (user indiva) — `/srv/backups/rsync-time-backup/`
- `stor01avanzait` (user avanzait) — `/storage/avanzait/rsync-time-backup/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)